### PR TITLE
Adz 637 update additional guidance

### DIFF
--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -147,7 +147,7 @@ info:
     This is the FHIR specification for Digital Medicines starting with the assets required for an electronic prescription sent to the EPS.
     
     ## Responses
-    ### 2xx responses
+    ### 2XX responses
     Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.
     
     | Endpoint               | HTTP code | Response format                                                                                                                                             |
@@ -155,7 +155,7 @@ info:
     | POST /$prepare         | 200       | [See /$prepare response body](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#api-Prescribing-preparePrescription)      |
     | POST /$process-message | 200       | [See /$process-message response body](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#api-Prescribing-sendPrescription) |
     
-    ### 4xx responses
+    ### 4XX responses
     Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.
     
     | Endpoint              | HTTP code | Response format                           | Environment      | Cause                 |
@@ -242,7 +242,7 @@ paths:
                 example:
                   value:
                     $ref: components/examples/example-1-repeat-dispensing/PrepareResponse-FhirMessageDigest.json
-        '4xx':
+        '4XX':
           description: Invalid request.
           content:
             application/fhir+json:
@@ -291,7 +291,7 @@ paths:
                 example:
                   value:
                     $ref: components/examples/example-1-repeat-dispensing/SendRequest-SuccessResponse.json
-        '4xx':
+        '4XX':
           description: Invalid request.
           content:
             application/fhir+json:

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -231,7 +231,7 @@ paths:
         description: ''
       responses:
         '200':
-          description: Successfully submitted.
+          description: Successful conversion.
           content:
             #FIXME - should be set to application/fhir+json but we have had to change it due to an Apigee SmartDocs bug.
             application/json:

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -139,9 +139,13 @@ info:
     **In step 11:** Submit your completed SCAL to api.management@nhs.net.
     **In step 14:** To request production access, contact us at api.management@nhs.net.
     
+    ## Additional guidance
+    
+    For further details on common HTTP status codes, see [5xx status codes](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide)
+    
     ## Responses
     ### 2xx responses
-    **Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.**
+    Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.**
     
     | Endpoint               | HTTP code | Response format                                                                                                                                             |
     | ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -149,7 +153,7 @@ info:
     | POST /$process-message | 200       | [See /$process-message response body](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#api-Prescribing-sendPrescription) |
     
     ### 4xx responses
-    **Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.**
+    Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.**
     
     | Endpoint              | HTTP code | Response format                           | Environment      | Cause                 |
     | --------------------- | --------- | ----------------------------------------- | ---------------- | --------------------- |
@@ -209,6 +213,7 @@ paths:
       operationId: prepare-prescription
       summary: Convert a prescription message to signature fragments
       description: |
+      ## Overview
         Use this endpoint to convert a [prescription-order message](https://simplifier.net/guide/DigitalMedicines/prescription-order) in FHIR format into HL7 V3 signature fragments which can then be signed by the prescriber.
       tags:
         - prescribing
@@ -226,7 +231,7 @@ paths:
         description: ''
       responses:
         '200':
-          description: Successful conversion.
+          description: Successfully submitted.
           content:
             #FIXME - should be set to application/fhir+json but we have had to change it due to an Apigee SmartDocs bug.
             application/json:
@@ -236,7 +241,7 @@ paths:
                 example:
                   value:
                     $ref: components/examples/example-1-repeat-dispensing/PrepareResponse-FhirMessageDigest.json
-        '4XX':
+        '4xx':
           description: Invalid request.
           content:
             application/fhir+json:
@@ -251,11 +256,12 @@ paths:
       operationId: send-message
       summary: Send a prescription message to EPS
       description: |
+        ## Overview
         Use this endpoint to send a prescription message to EPS.
         
         The effect of calling this endpoint depends on the type of the message, which is determined by the `MessageHeader` resource:
-        * To create a prescription, send a [prescription-order message](https://simplifier.net/guide/DigitalMedicines/prescription-order). The message must include a digital signature.
-        * To cancel a prescription, send a [prescription-order-update message](https://simplifier.net/guide/DigitalMedicines/prescription-order-update).
+        * to create a prescription, send a [prescription-order message](https://simplifier.net/guide/DigitalMedicines/prescription-order). The message must include a digital signature.
+        * to cancel a prescription, send a [prescription-order-update message](https://simplifier.net/guide/DigitalMedicines/prescription-order-update)
       tags:
         - prescribing
       requestBody:
@@ -284,7 +290,7 @@ paths:
                 example:
                   value:
                     $ref: components/examples/example-1-repeat-dispensing/SendRequest-SuccessResponse.json
-        '4XX':
+        '4xx':
           description: Invalid request.
           content:
             application/fhir+json:

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -188,7 +188,7 @@ info:
       }
       ```
     #### Validation errors
-    The endpoints return following errors based on the cause.
+    The endpoint can return the following errors:
     
     | HTTP code | Issue severity | Issue type | Error code             | Cause                                                           |
     | ----------| -------------- | ---------- | ---------------------- | --------------------------------------------------------------- |

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -187,7 +187,7 @@ info:
         ]
       }
       ```
-#### Validation errors
+    #### Validation errors
     The endpoint will return following errors in various environment  and will all return a 400 HTTP status code.
     
     | HTTP code | Issue severity | Issue type | Error code             | Cause                                                           |

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -188,7 +188,7 @@ info:
       }
       ```
     #### Validation errors
-    The endpoint will return following errors in various environment  and will all return a 400 HTTP status code.
+    The endpoints return following errors based on the cause.
     
     | HTTP code | Issue severity | Issue type | Error code             | Cause                                                           |
     | ----------| -------------- | ---------- | ---------------------- | --------------------------------------------------------------- |

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -140,8 +140,11 @@ info:
     **In step 14:** To request production access, contact us at api.management@nhs.net.
     
     ## Additional guidance
-    
     For further details on common HTTP status codes, see [5xx status codes](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide)
+    
+    ## Resources
+    Use the [Digital Medicines Implementation Guide](https://simplifier.net/guide/DigitalMedicines) to assist with your integration.
+    This is the FHIR specification for Digital Medicines starting with the assets required for an electronic prescription sent to the EPS.
     
     ## Responses
     ### 2xx responses
@@ -160,18 +163,7 @@ info:
     | Any                   | 400       | See "Unsupported operation" example below | Sandbox          | Unsupported operation |
     | Any                   | 408       | Returns original request data             | Integration test | Request timeout       |
     
-    #### Validation errors
-    The following errors may be returned by any endpoint in any environment and will all return a 400 HTTP status code.
-    
-    | Issue severity | Issue type | Error code             | Cause                                                           |
-    | -------------- | ---------- | ---------------------- | --------------------------------------------------------------- |
-    | error          | value      | MISSING_FIELD          | Bundle contains incorrect number of resources of a certain type |
-    | error          | value      | MISSING_FIELD          | Bundle does not contain "id" field                              |
-    | error          | value      | INVALID_VALUE          | Invalid value in MedicationRequest                              |
-    | fatal          | value      | MISSING_FIELD          | Bundle does not contain "entry" field                           |
-    | fatal          | value      | INCORRECT_RESOURCETYPE | ResourceType is not "Bundle"                                    |
-    | fatal          | value      | INVALID_VALUE          | MessageHeader indicates invalid MessageType                     |
-    
+        
     #### Example: Unsupported operation
     If attempting to call the `/_poll` endpoint in the sandbox environment, the following error would be returned:
       ```
@@ -195,11 +187,20 @@ info:
         ]
       }
       ```
+#### Validation errors
+    The endpoint will return following errors in various environment  and will all return a 400 HTTP status code.
+    
+    | HTTP code | Issue severity | Issue type | Error code             | Cause                                                           |
+    | ----------| -------------- | ---------- | ---------------------- | --------------------------------------------------------------- |
+    | 400       | error          | value      | MISSING_FIELD          | Bundle contains incorrect number of resources of a certain type |
+    | 400       | error          | value      | MISSING_FIELD          | Bundle does not contain "id" field                              |
+    | 400       | error          | value      | INVALID_VALUE          | Invalid value in MedicationRequest                              |
+    | 400       | fatal          | value      | MISSING_FIELD          | Bundle does not contain "entry" field                           |
+    | 400       | fatal          | value      | INCORRECT_RESOURCETYPE | ResourceType is not "Bundle"                                    |
+    | 400       | fatal          | value      | INVALID_VALUE          | MessageHeader indicates invalid MessageType                     |
 
-    ## Resources
-    Use the [Digital Medicines Implementation Guide](https://simplifier.net/guide/DigitalMedicines) to assist with your integration.
-    This is the FHIR specification for Digital Medicines starting with the assets required for an electronic prescription sent to the EPS.
-servers:
+
+ servers:
   - url: 'https://sandbox.api.service.nhs.uk/electronic-prescriptions'
     description: 'Sandbox'
   - url: 'https://int.api.service.nhs.uk/electronic-prescriptions'

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -188,7 +188,7 @@ info:
       }
       ```
     #### Validation errors
-    The endpoint can return the following errors:
+    Our endpoints can return the following errors:
     
     | HTTP code | Issue severity | Issue type | Error code             | Cause                                                           |
     | ----------| -------------- | ---------- | ---------------------- | --------------------------------------------------------------- |

--- a/specification/electronic-prescription-service-api.yaml
+++ b/specification/electronic-prescription-service-api.yaml
@@ -148,7 +148,7 @@ info:
     
     ## Responses
     ### 2xx responses
-    Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.**
+    Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.
     
     | Endpoint               | HTTP code | Response format                                                                                                                                             |
     | ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -156,7 +156,7 @@ info:
     | POST /$process-message | 200       | [See /$process-message response body](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#api-Prescribing-sendPrescription) |
     
     ### 4xx responses
-    Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.**
+    Note: This section is under development and subject to change. All Spine responses are returned with 200 HTTP codes until a Spine translation service is built. This does not affect the sandbox environment.
     
     | Endpoint              | HTTP code | Response format                           | Environment      | Cause                 |
     | --------------------- | --------- | ----------------------------------------- | ---------------- | --------------------- |
@@ -200,7 +200,7 @@ info:
     | 400       | fatal          | value      | INVALID_VALUE          | MessageHeader indicates invalid MessageType                     |
 
 
- servers:
+servers:
   - url: 'https://sandbox.api.service.nhs.uk/electronic-prescriptions'
     description: 'Sandbox'
   - url: 'https://int.api.service.nhs.uk/electronic-prescriptions'
@@ -214,7 +214,7 @@ paths:
       operationId: prepare-prescription
       summary: Convert a prescription message to signature fragments
       description: |
-      ## Overview
+        ## Overview
         Use this endpoint to convert a [prescription-order message](https://simplifier.net/guide/DigitalMedicines/prescription-order) in FHIR format into HL7 V3 signature fragments which can then be signed by the prescriber.
       tags:
         - prescribing


### PR DESCRIPTION
I have made following changes to the EPS FHIR API specs.

- Added Additional guidance section to the spec
- Change the bold Note below 2xx & 4xx codes to non-bold
- Changed Successful conversion to Successfully submitted
- Removed full stop after bullet points
- Added Overview before description of the endpoints
- Added column HTTP Code to Validation error table 
- Moved Validation Error table below the Example: Unsupported operation