### PR TITLE
AEA-1779: Fix NHS number verification status in release response.

### DIFF
--- a/coordinator/src/services/translation/response/patient.ts
+++ b/coordinator/src/services/translation/response/patient.ts
@@ -26,7 +26,7 @@ function createNhsNumberIdentifier(nhsNumber: string): Array<fhir.PatientIdentif
             coding: [
               {
                 system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus",
-                code: "01",
+                code: "number-present-and-verified",
                 display: "Number present and verified"
               }
             ]

--- a/coordinator/src/services/translation/response/release/release-response.ts
+++ b/coordinator/src/services/translation/response/release/release-response.ts
@@ -98,9 +98,13 @@ export function createBundleResources(
   const patientInfo = firstItemAdditionalInstructions.patientInfo
   if (medication.length || patientInfo.length) {
     const patientIdentifier = fhirPatient.identifier[0]
+    const patientIdentifierWithoutExtension = {
+      system: patientIdentifier.system,
+      value: patientIdentifier.value
+    }
     const organizationIdentifier = translatedAuthor.healthcareService.identifier[0]
     const translatedAdditionalInstructions = translateAdditionalInstructions(
-      patientId, patientIdentifier, organizationIdentifier, medication, patientInfo
+      patientId, patientIdentifierWithoutExtension, organizationIdentifier, medication, patientInfo
     )
     addTranslatedAdditionalInstructions(bundleResources, translatedAdditionalInstructions)
   }


### PR DESCRIPTION
- Use the new textual code instead of the old numeric one.
- Exclude the extension entirely in the context of CommunicationRequest.recipient.