### PR TITLE
APM-2869 Associate products with oauth mock service

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -87,6 +87,10 @@ apigee:
           - identity-service-{{ ENV.name }}
 {% if ENV.name == 'int' %}
           - identity-service-int-no-smartcard
+          - identity-service-mock-{{ ENV.name }}
+{% endif %}
+{% if ENV.name == 'internal-dev' or ENV.name == 'internal-qa' %}
+          - identity-service-mock-{{ ENV.name }}
 {% endif %}
         scopes: {{ PRODUCT.scopes }}
         quota: {{ ENV.quota | default('300') }}


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/APM-2869

Associating the relevant products that can use mock-oauth with the corrisponding identity-service proxy