### PR TITLE
AEA-2527 Population of Prescriber Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a RESTful HL7® FHIR® API specification for the *Electronic Prescriptio
 * `specification/` This [Open API Specification](https://swagger.io/docs/specification/about/) describes the endpoints, methods and messages exchanged by the API. Use it to generate interactive documentation; the contract between the API and its consumers.
 * `tests/` End-to-end testing of the EPS FHIR API.
 
-Consumers of the API will find developer documentation on the [NHS Digital Developer Hub](https://emea-demo8-nhsdportal.apigee.io/).
+Consumers of the API will find developer documentation on the [NHS Digital Developer Hub](https://digital.nhs.uk/developer/api-catalogue).
 
 ## Contributing
 Contributions to this project are welcome from anyone, providing that they conform to the [guidelines for contribution](https://github.com/NHSDigital/electronic-prescription-service-api/blob/master/CONTRIBUTING.md) and the [community code of conduct](https://github.com/NHSDigital/electronic-prescription-service-api/blob/master/CODE_OF_CONDUCT.md).

--- a/coordinator/src/services/validation/bundle-validator.ts
+++ b/coordinator/src/services/validation/bundle-validator.ts
@@ -227,7 +227,13 @@ export function verifyPrescriptionBundle(bundle: fhir.Bundle): Array<fhir.Operat
   )
   if (gmpCode) {
     if (practitioner.identifier.length === 1) {
-      allErrors.push(errors.createInvalidIdentifierIssue("Practitioner.identifier"))
+      allErrors.push(
+        errors.createInvalidIdentifierIssue(
+          "Practitioner",
+          "GMC|DIN",
+          "GMP"
+        )
+      )
     }
   }
 

--- a/coordinator/src/services/validation/bundle-validator.ts
+++ b/coordinator/src/services/validation/bundle-validator.ts
@@ -9,8 +9,10 @@ import {getUniqueValues} from "../../utils/collections"
 import {
   getExtensionForUrlOrNull,
   getIdentifierValueForSystem,
+  getIdentifierValueOrNullForSystem,
   identifyMessageType,
   isTruthy,
+  resolvePractitioner,
   resolveReference
 } from "../translation/common"
 import {fhir, processingErrors, validationErrors as errors} from "@models"
@@ -212,6 +214,21 @@ export function verifyPrescriptionBundle(bundle: fhir.Bundle): Array<fhir.Operat
     }
   } else {
     allErrors.push(errors.fieldIsNotReferenceButShouldBe("practitionerRole.organization"))
+  }
+
+  const practitioner = resolvePractitioner(
+    bundle,
+    practitionerRole.practitioner
+  )
+  const gmpCode = getIdentifierValueOrNullForSystem(
+    practitioner.identifier,
+    "https://fhir.hl7.org.uk/Id/gmp-number",
+    "Practitioner.identifier"
+  )
+  if (gmpCode) {
+    if (practitioner.identifier.length === 1) {
+      allErrors.push(errors.createInvalidIdentifierIssue("Practitioner.identifier"))
+    }
   }
 
   const repeatDispensingErrors =

--- a/coordinator/src/services/validation/bundle-validator.ts
+++ b/coordinator/src/services/validation/bundle-validator.ts
@@ -230,8 +230,8 @@ export function verifyPrescriptionBundle(bundle: fhir.Bundle): Array<fhir.Operat
       allErrors.push(
         errors.createInvalidIdentifierIssue(
           "Practitioner",
-          "GMC|DIN",
-          "GMP"
+          "GMP",
+          "GMC|NMC|GPhC|HCPC|DIN|unknown"
         )
       )
     }

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -17,7 +17,6 @@ import {
   PRESCRIBING_USER_SCOPE
 } from "../../../src/services/validation/scope-validator"
 import {isReference} from "../../../src/utils/type-guards"
-import {createIdentifier} from "../../../../models/fhir"
 
 jest.spyOn(global.console, "warn").mockImplementation(() => null)
 
@@ -450,7 +449,7 @@ describe("MedicationRequest consistency checks", () => {
   })
 
   test("Should throw error when GMP-number is only number in Practitioner.identifier", () => {
-    const testReference: fhir.Identifier = createIdentifier("https://fhir.hl7.org.uk/Id/gmp-number", "G1234567")
+    const testReference: fhir.Identifier = fhir.createIdentifier("https://fhir.hl7.org.uk/Id/gmp-number", "G1234567")
     if (isReference(practitionerRoles[0].practitioner)) {
       const practitioner = resolveReference(bundle, practitionerRoles[0].practitioner)
       practitioner.identifier = [testReference]

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -458,7 +458,7 @@ describe("MedicationRequest consistency checks", () => {
     const validationErrors = validator.verifyPrescriptionBundle(bundle)
     expect(validationErrors).toHaveLength(1)
     // eslint-disable-next-line max-len
-    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|DIN.")
+    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|NMC|GPhC|HCPC|DIN|unknown.")
   })
 })
 

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -6,7 +6,8 @@ import {
   getExtensionForUrl,
   getExtensionForUrlOrNull,
   isTruthy,
-  resolveOrganization
+  resolveOrganization,
+  resolveReference
 } from "../../../src/services/translation/common"
 import {fhir, validationErrors as errors} from "@models"
 import {
@@ -15,6 +16,8 @@ import {
   PRESCRIBING_APP_SCOPE,
   PRESCRIBING_USER_SCOPE
 } from "../../../src/services/validation/scope-validator"
+import {isReference} from "../../../src/utils/type-guards"
+import {createIdentifier} from "../../../../models/fhir"
 
 jest.spyOn(global.console, "warn").mockImplementation(() => null)
 
@@ -416,10 +419,10 @@ describe("MedicationRequest consistency checks", () => {
     ) as fhir.CodingExtension
     prescriptionTypeExtension.valueCoding.code = "0101"
 
-    delete(practitionerRoles[0].healthcareService)
+    delete (practitionerRoles[0].healthcareService)
 
     const organization = resolveOrganization(bundle, practitionerRoles[0])
-    delete(organization.partOf)
+    delete (organization.partOf)
 
     const validationErrors = validator.verifyPrescriptionBundle(bundle)
     expect(validationErrors).toHaveLength(2)
@@ -446,6 +449,16 @@ describe("MedicationRequest consistency checks", () => {
     expect(validationErrors).toHaveLength(1)
   })
 
+  test("Should throw error when GMP-number is only number in Practitioner.identifier", () => {
+    const testReference: fhir.Identifier = createIdentifier("https://fhir.hl7.org.uk/Id/gmp-number", "G1234567")
+    if (isReference(practitionerRoles[0].practitioner)) {
+      const practitioner = resolveReference(bundle, practitionerRoles[0].practitioner)
+      practitioner.identifier = [testReference]
+    }
+
+    const validationErrors = validator.verifyPrescriptionBundle(bundle)
+    expect(validationErrors).toHaveLength(1)
+  })
 })
 
 describe("verifyRepeatDispensingPrescription", () => {

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -458,6 +458,8 @@ describe("MedicationRequest consistency checks", () => {
 
     const validationErrors = validator.verifyPrescriptionBundle(bundle)
     expect(validationErrors).toHaveLength(1)
+    // eslint-disable-next-line max-len
+    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|DIN.")
   })
 })
 

--- a/models/errors/validation-errors.ts
+++ b/models/errors/validation-errors.ts
@@ -239,11 +239,15 @@ export const unexpectedField = (fhirPath: string): fhir.OperationOutcomeIssue =>
   diagnostics: `Unexpected field of ${fhirPath}.`
 })
 
-export function createInvalidIdentifierIssue(identifier: string): fhir.OperationOutcomeIssue {
+export function createInvalidIdentifierIssue(
+  resource: string,
+  acceptedList: string,
+  incorrectIdentifier: string
+): fhir.OperationOutcomeIssue {
   return {
     severity: "error",
     code: fhir.IssueCodes.VALUE,
-    diagnostics: `${identifier} contains unsuitable identifier, 
-      creating a prescription requires a suitable identifier such as a GMC Reference Number`
+    // eslint-disable-next-line max-len
+    diagnostics: `Expected ${resource}.identifier to contain more identifiers than ${incorrectIdentifier}. Also expected one of ${acceptedList}.`
   }
 }

--- a/models/errors/validation-errors.ts
+++ b/models/errors/validation-errors.ts
@@ -241,8 +241,8 @@ export const unexpectedField = (fhirPath: string): fhir.OperationOutcomeIssue =>
 
 export function createInvalidIdentifierIssue(
   resource: string,
-  acceptedList: string,
-  incorrectIdentifier: string
+  incorrectIdentifier: string,
+  acceptedList: string
 ): fhir.OperationOutcomeIssue {
   return {
     severity: "error",

--- a/models/errors/validation-errors.ts
+++ b/models/errors/validation-errors.ts
@@ -238,3 +238,12 @@ export const unexpectedField = (fhirPath: string): fhir.OperationOutcomeIssue =>
   code: fhir.IssueCodes.INVALID,
   diagnostics: `Unexpected field of ${fhirPath}.`
 })
+
+export function createInvalidIdentifierIssue(identifier: string): fhir.OperationOutcomeIssue {
+  return {
+    severity: "error",
+    code: fhir.IssueCodes.VALUE,
+    diagnostics: `${identifier} contains unsuitable identifier, 
+      creating a prescription requires a suitable identifier such as a GMC Reference Number`
+  }
+}


### PR DESCRIPTION
AC 1.1
WHEN a GMP code is the only professional identifier that is provided for a prescriber,
THEN the FHIR Facade API needs to reject this
AND request that a more suitable identifier, e.g. a GMC Reference Number, is provided for the creation of a prescription