### PR TITLE
Update nvm and Node versions in setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ These can be installed by running the following commands:
 & sudo apt update
 $ sudo apt install git make curl npm python3-apt python3-distutils python3-venv default-jre shellcheck build-essential checkinstall libssl-dev maven -y
 $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
-$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.37.2/install.sh | bash
-$ nvm install v14.15.4
+$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.1/install.sh | bash
+$ nvm install v16.14
 ```
 
 Install packages:


### PR DESCRIPTION
We're now on Node 16.14.x
nvm also has a newer version, so we can upgrade to the latest