### PR TITLE
Testing some logging to try diagnose issue

### DIFF
--- a/coordinator/src/services/translation/request/prescription.ts
+++ b/coordinator/src/services/translation/request/prescription.ts
@@ -87,11 +87,12 @@ export function convertPrescriptionComponent1(
   expectedSupplyDuration: fhir.SimpleQuantity
 ): hl7V3.Component1 {
   const daysSupply = new hl7V3.DaysSupply()
-
+  console.log(validityPeriod)
   const low = convertIsoDateTimeStringToHl7V3Date(
     validityPeriod.start,
     "MedicationRequest.dispenseRequest.validityPeriod.start"
   )
+  console.warn(validityPeriod)
   const high = convertIsoDateTimeStringToHl7V3Date(
     validityPeriod.end,
     "MedicationRequest.dispenseRequest.validityPeriod.end"


### PR DESCRIPTION
Looking into Splunk logs, apparently it is to do with incorrect format for date time under validityPeriod.end but nothing indicates this is the issue at surface level.