### PR TITLE
Aea 2560 remove organisation type in cancel response

### DIFF
--- a/coordinator/src/services/translation/response/organization.ts
+++ b/coordinator/src/services/translation/response/organization.ts
@@ -1,10 +1,5 @@
-import {
-  convertAddress,
-  convertTelecom,
-  generateResourceId,
-  isSecondaryCare
-} from "./common"
-import { hl7V3, fhir } from "@models"
+import {convertAddress, convertTelecom, generateResourceId} from "./common"
+import {hl7V3, fhir} from "@models"
 
 export function createOrganization(hl7Organization: hl7V3.Organization): fhir.Organization {
   const organization: fhir.Organization = {
@@ -56,32 +51,4 @@ export function createHealthcareService(
 
 export function getOrganizationCodeIdentifier(organizationId: string): fhir.Identifier {
   return fhir.createIdentifier("https://fhir.nhs.uk/Id/ods-organization-code", organizationId)
-}
-
-function getOrganizationType(hl7Organization: hl7V3.Organization) {
-  if (isSecondaryCare(hl7Organization)) {
-    return [
-      {
-        coding: [
-          {
-            system: "https://fhir.nhs.uk/CodeSystem/organisation-role",
-            code: "197",
-            display: "NHS TRUST"
-          }
-        ]
-      }
-    ]
-  } else {
-    return [
-      {
-        coding: [
-          {
-            system: "https://fhir.nhs.uk/CodeSystem/organisation-role",
-            code: "179",
-            display: "PRIMARY CARE TRUST"
-          }
-        ]
-      }
-    ]
-  }
 }

--- a/coordinator/src/services/translation/response/organization.ts
+++ b/coordinator/src/services/translation/response/organization.ts
@@ -4,14 +4,13 @@ import {
   generateResourceId,
   isSecondaryCare
 } from "./common"
-import {hl7V3, fhir} from "@models"
+import { hl7V3, fhir } from "@models"
 
 export function createOrganization(hl7Organization: hl7V3.Organization): fhir.Organization {
   const organization: fhir.Organization = {
     resourceType: "Organization",
     id: generateResourceId(),
-    identifier: [getOrganizationCodeIdentifier(hl7Organization.id._attributes.extension)],
-    type: getOrganizationType(hl7Organization)
+    identifier: [getOrganizationCodeIdentifier(hl7Organization.id._attributes.extension)]
   }
   if (hl7Organization.name) {
     organization.name = hl7Organization.name._text
@@ -63,7 +62,7 @@ function getOrganizationType(hl7Organization: hl7V3.Organization) {
   if (isSecondaryCare(hl7Organization)) {
     return [
       {
-        coding:  [
+        coding: [
           {
             system: "https://fhir.nhs.uk/CodeSystem/organisation-role",
             code: "197",
@@ -75,7 +74,7 @@ function getOrganizationType(hl7Organization: hl7V3.Organization) {
   } else {
     return [
       {
-        coding:  [
+        coding: [
           {
             system: "https://fhir.nhs.uk/CodeSystem/organisation-role",
             code: "179",

--- a/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
+++ b/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
@@ -12,14 +12,16 @@ import {
   getPractitionerRoles,
   getPractitioners
 } from "../../../../../src/services/translation/common/getResourcesOfType"
-import {getCancellationResponse, hasCorrectISOFormat} from "../../common/test-helpers"
-import {CANCEL_RESPONSE_HANDLER} from "../../../../../src/services/translation/response"
+import { getCancellationResponse, hasCorrectISOFormat } from "../../common/test-helpers"
+import { CANCEL_RESPONSE_HANDLER } from "../../../../../src/services/translation/response"
 import {
   extractStatusCode
 } from "../../../../../src/services/translation/response/cancellation/cancellation-medication-request"
-import {fhir} from "@models"
-import {getPerformer, getRequester, getResponsiblePractitioner} from "../common.spec"
-import {resolvePractitioner} from "../../../../../src/services/translation/common"
+import { fhir } from "@models"
+import { getPerformer, getRequester, getResponsiblePractitioner } from "../common.spec"
+import { resolvePractitioner } from "../../../../../src/services/translation/common"
+import { Organization as IOrgansation } from "../../../../../../models/fhir/practitioner-role"
+
 
 const actualError = TestResources.spineResponses.cancellationNotFoundError
 const actualSendMessagePayload = CANCEL_RESPONSE_HANDLER.extractSendMessagePayload(actualError.response.body)
@@ -104,6 +106,12 @@ describe("bundle entries", () => {
     const organizations = getOrganizations(performerFhirBundle)
     const postcodes = organizations.flatMap(organization => organization.address.map(a => a.postalCode))
     expect(postcodes).toContain("PR26 7QN")
+  })
+
+  test("organisation should not contain type field", () => {
+    const organisations = getOrganizations(performerFhirBundle);
+    const organisation: IOrgansation = organisations[0];
+    expect(organisation.type).toEqual(undefined);
   })
 
   test("performer field in hl7 message adds dispense reference to MedicationRequest", () => {

--- a/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
+++ b/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
@@ -108,7 +108,7 @@ describe("bundle entries", () => {
     expect(postcodes).toContain("PR26 7QN")
   })
 
-  test("organisation should not contain type field", () => {
+  test("organisation should not contain a type field", () => {
     const organisations = getOrganizations(performerFhirBundle);
     const organisation: IOrgansation = organisations[0];
     expect(organisation.type).toBeUndefined();

--- a/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
+++ b/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
@@ -12,16 +12,15 @@ import {
   getPractitionerRoles,
   getPractitioners
 } from "../../../../../src/services/translation/common/getResourcesOfType"
-import { getCancellationResponse, hasCorrectISOFormat } from "../../common/test-helpers"
-import { CANCEL_RESPONSE_HANDLER } from "../../../../../src/services/translation/response"
+import {getCancellationResponse, hasCorrectISOFormat} from "../../common/test-helpers"
+import {CANCEL_RESPONSE_HANDLER} from "../../../../../src/services/translation/response"
 import {
   extractStatusCode
 } from "../../../../../src/services/translation/response/cancellation/cancellation-medication-request"
-import { fhir } from "@models"
-import { getPerformer, getRequester, getResponsiblePractitioner } from "../common.spec"
-import { resolvePractitioner } from "../../../../../src/services/translation/common"
-import { Organization as IOrgansation } from "../../../../../../models/fhir/practitioner-role"
-
+import {fhir} from "@models"
+import {getPerformer, getRequester, getResponsiblePractitioner} from "../common.spec"
+import {resolvePractitioner} from "../../../../../src/services/translation/common"
+import {Organization as IOrgansation} from "../../../../../../models/fhir/practitioner-role"
 
 const actualError = TestResources.spineResponses.cancellationNotFoundError
 const actualSendMessagePayload = CANCEL_RESPONSE_HANDLER.extractSendMessagePayload(actualError.response.body)
@@ -109,9 +108,9 @@ describe("bundle entries", () => {
   })
 
   test("organisation should not contain a type field", () => {
-    const organisations = getOrganizations(performerFhirBundle);
-    const organisation: IOrgansation = organisations[0];
-    expect(organisation.type).toBeUndefined();
+    const organisations = getOrganizations(performerFhirBundle)
+    const organisation: IOrgansation = organisations[0]
+    expect(organisation.type).toBeUndefined()
   })
 
   test("performer field in hl7 message adds dispense reference to MedicationRequest", () => {

--- a/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
+++ b/coordinator/tests/services/translation/response/cancellation/cancellation-response.spec.ts
@@ -111,7 +111,7 @@ describe("bundle entries", () => {
   test("organisation should not contain type field", () => {
     const organisations = getOrganizations(performerFhirBundle);
     const organisation: IOrgansation = organisations[0];
-    expect(organisation.type).toEqual(undefined);
+    expect(organisation.type).toBeUndefined();
   })
 
   test("performer field in hl7 message adds dispense reference to MedicationRequest", () => {

--- a/coordinator/tests/services/translation/response/organization.spec.ts
+++ b/coordinator/tests/services/translation/response/organization.spec.ts
@@ -1,12 +1,12 @@
 import * as TestResources from "../../../resources/test-resources"
-import {getIdentifierValueForSystem} from "../../../../src/services/translation/common"
+import { getIdentifierValueForSystem } from "../../../../src/services/translation/common"
 import {
   createHealthcareService,
   createLocations,
   createOrganization
 } from "../../../../src/services/translation/response/organization"
-import {getCancellationResponse} from "../common/test-helpers"
-import {hl7V3, fhir} from "@models"
+import { getCancellationResponse } from "../common/test-helpers"
+import { hl7V3, fhir } from "@models"
 
 const cancellationResponse = getCancellationResponse(TestResources.spineResponses.cancellationNotFoundError)
 const cancellationDispensedResponse = getCancellationResponse(TestResources.spineResponses.cancellationDispensedError)
@@ -38,12 +38,6 @@ describe.each([
       expect(identifierValue).toBe(hl7Organization.id._attributes.extension)
     })
 
-    test("%p has a type block with correct coding values", () => {
-      expect(fhirOrganization.type).not.toBeUndefined()
-      expect(fhirOrganization.type[0].coding[0].code).toBe(organisationTypeCode)
-      expect(fhirOrganization.type[0].coding[0].display).toBeTruthy()
-    })
-
     test("%p has correct name value", () => {
       expect(fhirOrganization.name).toBe(hl7Organization.name._text)
     })
@@ -63,7 +57,7 @@ describe.each([
 
     test("empty name gets translated", () => {
       const organizationWithoutName = createOrganization(
-        {...performerRepresentedOrganization, name: undefined}
+        { ...performerRepresentedOrganization, name: undefined }
       )
 
       expect(organizationWithoutName.name).toBeUndefined()
@@ -71,7 +65,7 @@ describe.each([
 
     test("empty telecom gets translated", () => {
       const organizationWithoutTelecom = createOrganization(
-        {...performerRepresentedOrganization, telecom: undefined}
+        { ...performerRepresentedOrganization, telecom: undefined }
       )
 
       expect(organizationWithoutTelecom.telecom).toBeUndefined()
@@ -79,7 +73,7 @@ describe.each([
 
     test("empty address gets translated", () => {
       const organizationWithoutAddress = createOrganization(
-        {...performerRepresentedOrganization, addr: undefined}
+        { ...performerRepresentedOrganization, addr: undefined }
       )
 
       expect(organizationWithoutAddress.address).toBeUndefined()
@@ -137,7 +131,7 @@ describe.each([
 
     test("empty name gets translated", () => {
       const healthcareServiceWithoutName = createHealthcareService(
-        {...performerRepresentedOrganization, name: undefined}, performerLocations
+        { ...performerRepresentedOrganization, name: undefined }, performerLocations
       )
 
       expect(healthcareServiceWithoutName.name).toBeUndefined()
@@ -145,7 +139,7 @@ describe.each([
 
     test("empty telecom gets translated", () => {
       const healthcareServiceWithoutTelecom = createHealthcareService(
-        {...performerRepresentedOrganization, telecom: undefined}, performerLocations
+        { ...performerRepresentedOrganization, telecom: undefined }, performerLocations
       )
 
       expect(healthcareServiceWithoutTelecom.telecom).toBeUndefined()

--- a/coordinator/tests/services/translation/response/organization.spec.ts
+++ b/coordinator/tests/services/translation/response/organization.spec.ts
@@ -1,12 +1,12 @@
 import * as TestResources from "../../../resources/test-resources"
-import { getIdentifierValueForSystem } from "../../../../src/services/translation/common"
+import {getIdentifierValueForSystem} from "../../../../src/services/translation/common"
 import {
   createHealthcareService,
   createLocations,
   createOrganization
 } from "../../../../src/services/translation/response/organization"
-import { getCancellationResponse } from "../common/test-helpers"
-import { hl7V3, fhir } from "@models"
+import {getCancellationResponse} from "../common/test-helpers"
+import {hl7V3, fhir} from "@models"
 
 const cancellationResponse = getCancellationResponse(TestResources.spineResponses.cancellationNotFoundError)
 const cancellationDispensedResponse = getCancellationResponse(TestResources.spineResponses.cancellationDispensedError)
@@ -25,8 +25,7 @@ describe.each([
   (
     organizationName: string,
     fhirOrganization: fhir.Organization,
-    hl7Organization: hl7V3.Organization,
-    organisationTypeCode: string
+    hl7Organization: hl7V3.Organization
   ) => {
     test("%p has an identifier block with the correct value", () => {
       expect(fhirOrganization.identifier).not.toBeUndefined()
@@ -57,7 +56,7 @@ describe.each([
 
     test("empty name gets translated", () => {
       const organizationWithoutName = createOrganization(
-        { ...performerRepresentedOrganization, name: undefined }
+        {...performerRepresentedOrganization, name: undefined}
       )
 
       expect(organizationWithoutName.name).toBeUndefined()
@@ -65,7 +64,7 @@ describe.each([
 
     test("empty telecom gets translated", () => {
       const organizationWithoutTelecom = createOrganization(
-        { ...performerRepresentedOrganization, telecom: undefined }
+        {...performerRepresentedOrganization, telecom: undefined}
       )
 
       expect(organizationWithoutTelecom.telecom).toBeUndefined()
@@ -73,7 +72,7 @@ describe.each([
 
     test("empty address gets translated", () => {
       const organizationWithoutAddress = createOrganization(
-        { ...performerRepresentedOrganization, addr: undefined }
+        {...performerRepresentedOrganization, addr: undefined}
       )
 
       expect(organizationWithoutAddress.address).toBeUndefined()
@@ -131,7 +130,7 @@ describe.each([
 
     test("empty name gets translated", () => {
       const healthcareServiceWithoutName = createHealthcareService(
-        { ...performerRepresentedOrganization, name: undefined }, performerLocations
+        {...performerRepresentedOrganization, name: undefined}, performerLocations
       )
 
       expect(healthcareServiceWithoutName.name).toBeUndefined()
@@ -139,7 +138,7 @@ describe.each([
 
     test("empty telecom gets translated", () => {
       const healthcareServiceWithoutTelecom = createHealthcareService(
-        { ...performerRepresentedOrganization, telecom: undefined }, performerLocations
+        {...performerRepresentedOrganization, telecom: undefined}, performerLocations
       )
 
       expect(healthcareServiceWithoutTelecom.telecom).toBeUndefined()

--- a/coordinator/tests/services/translation/response/release/release-response.spec.ts
+++ b/coordinator/tests/services/translation/response/release/release-response.spec.ts
@@ -2,13 +2,13 @@ import {
   createInnerBundle,
   createOuterBundle
 } from "../../../../../src/services/translation/response/release/release-response"
-import {readXmlStripNamespace} from "../../../../../src/services/serialisation/xml"
+import { readXmlStripNamespace } from "../../../../../src/services/serialisation/xml"
 import * as LosslessJson from "lossless-json"
 import * as fs from "fs"
 import * as path from "path"
-import {getUniqueValues} from "../../../../../src/utils/collections"
-import {resolveOrganization, resolvePractitioner, toArray} from "../../../../../src/services/translation/common"
-import {fhir, hl7V3} from "@models"
+import { getUniqueValues } from "../../../../../src/utils/collections"
+import { resolveOrganization, resolvePractitioner, toArray } from "../../../../../src/services/translation/common"
+import { fhir, hl7V3 } from "@models"
 import {
   getLocations,
   getMedicationRequests,
@@ -19,7 +19,8 @@ import {
   getPractitioners,
   getProvenances
 } from "../../../../../src/services/translation/common/getResourcesOfType"
-import {getRequester, getResponsiblePractitioner} from "../common.spec"
+import { getRequester, getResponsiblePractitioner } from "../common.spec"
+import { Organization as IOrgansation } from "../../../../../../models/fhir/practitioner-role"
 
 describe("outer bundle", () => {
   const result = createOuterBundle(getExamplePrescriptionReleaseResponse("release_success.xml"))
@@ -136,6 +137,12 @@ describe("bundle resources", () => {
   test("contains Organization", () => {
     const organizations = getOrganizations(result)
     expect(organizations).toHaveLength(1)
+  })
+
+  test("organisation should not contain a type field", () => {
+    const organisations = getOrganizations(result);
+    const organisation: IOrgansation = organisations[0];
+    expect(organisation.type).toBeUndefined();
   })
 
   test("contains MedicationRequests", () => {

--- a/coordinator/tests/services/translation/response/release/release-response.spec.ts
+++ b/coordinator/tests/services/translation/response/release/release-response.spec.ts
@@ -2,13 +2,13 @@ import {
   createInnerBundle,
   createOuterBundle
 } from "../../../../../src/services/translation/response/release/release-response"
-import { readXmlStripNamespace } from "../../../../../src/services/serialisation/xml"
+import {readXmlStripNamespace} from "../../../../../src/services/serialisation/xml"
 import * as LosslessJson from "lossless-json"
 import * as fs from "fs"
 import * as path from "path"
-import { getUniqueValues } from "../../../../../src/utils/collections"
-import { resolveOrganization, resolvePractitioner, toArray } from "../../../../../src/services/translation/common"
-import { fhir, hl7V3 } from "@models"
+import {getUniqueValues} from "../../../../../src/utils/collections"
+import {resolveOrganization, resolvePractitioner, toArray} from "../../../../../src/services/translation/common"
+import {fhir, hl7V3} from "@models"
 import {
   getLocations,
   getMedicationRequests,
@@ -19,8 +19,8 @@ import {
   getPractitioners,
   getProvenances
 } from "../../../../../src/services/translation/common/getResourcesOfType"
-import { getRequester, getResponsiblePractitioner } from "../common.spec"
-import { Organization as IOrgansation } from "../../../../../../models/fhir/practitioner-role"
+import {getRequester, getResponsiblePractitioner} from "../common.spec"
+import {Organization as IOrgansation} from "../../../../../../models/fhir/practitioner-role"
 
 describe("outer bundle", () => {
   const result = createOuterBundle(getExamplePrescriptionReleaseResponse("release_success.xml"))
@@ -140,9 +140,9 @@ describe("bundle resources", () => {
   })
 
   test("organisation should not contain a type field", () => {
-    const organisations = getOrganizations(result);
-    const organisation: IOrgansation = organisations[0];
-    expect(organisation.type).toBeUndefined();
+    const organisations = getOrganizations(result)
+    const organisation: IOrgansation = organisations[0]
+    expect(organisation.type).toBeUndefined()
   })
 
   test("contains MedicationRequests", () => {


### PR DESCRIPTION
createOrganization function now creates Organisation with the type field not populated by default. The createOrganization method is used to populate organisation for the cancel response and release response. Tests updated appropriately. 