### PR TITLE
AEA-2527 Population Prescriber Update

### DIFF
--- a/coordinator/src/services/validation/bundle-validator.ts
+++ b/coordinator/src/services/validation/bundle-validator.ts
@@ -230,7 +230,6 @@ export function verifyPrescriptionBundle(bundle: fhir.Bundle): Array<fhir.Operat
     allErrors.push(
       errors.createInvalidIdentifierIssue(
         "Practitioner",
-        "GMP",
         "GMC|NMC|GPhC|HCPC|professional-code"
       )
     )

--- a/coordinator/src/services/validation/bundle-validator.ts
+++ b/coordinator/src/services/validation/bundle-validator.ts
@@ -227,15 +227,13 @@ export function verifyPrescriptionBundle(bundle: fhir.Bundle): Array<fhir.Operat
     "Practitioner.identifier"
   )
   if (gmpCode) {
-    if (practitioner.identifier.length === 1) {
-      allErrors.push(
-        errors.createInvalidIdentifierIssue(
-          "Practitioner",
-          "GMP",
-          "GMC|NMC|GPhC|HCPC|DIN|unknown"
-        )
+    allErrors.push(
+      errors.createInvalidIdentifierIssue(
+        "Practitioner",
+        "GMP",
+        "GMC|NMC|GPhC|HCPC|unknown"
       )
-    }
+    )
   }
 
   const repeatDispensingErrors =

--- a/coordinator/src/services/validation/bundle-validator.ts
+++ b/coordinator/src/services/validation/bundle-validator.ts
@@ -231,7 +231,7 @@ export function verifyPrescriptionBundle(bundle: fhir.Bundle): Array<fhir.Operat
       errors.createInvalidIdentifierIssue(
         "Practitioner",
         "GMP",
-        "GMC|NMC|GPhC|HCPC|unknown"
+        "GMC|NMC|GPhC|HCPC|professional-code"
       )
     )
   }

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -482,7 +482,7 @@ describe("MedicationRequest consistency checks", () => {
     const validationErrors = validator.verifyPrescriptionBundle(bundle)
     expect(validationErrors).toHaveLength(1)
     // eslint-disable-next-line max-len
-    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|NMC|GPhC|HCPC|unknown.")
+    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|NMC|GPhC|HCPC|professional-code.")
   })
 })
 

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -482,7 +482,7 @@ describe("MedicationRequest consistency checks", () => {
     const validationErrors = validator.verifyPrescriptionBundle(bundle)
     expect(validationErrors).toHaveLength(1)
     // eslint-disable-next-line max-len
-    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|NMC|GPhC|HCPC|DIN|unknown.")
+    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|NMC|GPhC|HCPC|unknown.")
   })
 })
 

--- a/coordinator/tests/services/validation/bundle-validator.spec.ts
+++ b/coordinator/tests/services/validation/bundle-validator.spec.ts
@@ -482,7 +482,7 @@ describe("MedicationRequest consistency checks", () => {
     const validationErrors = validator.verifyPrescriptionBundle(bundle)
     expect(validationErrors).toHaveLength(1)
     // eslint-disable-next-line max-len
-    expect(validationErrors[0].diagnostics).toEqual("Expected Practitioner.identifier to contain more identifiers than GMP. Also expected one of GMC|NMC|GPhC|HCPC|professional-code.")
+    expect(validationErrors[0].diagnostics).toEqual("Bundle resource Practitioner.identifier expected exactly one professional code from GMC|NMC|GPhC|HCPC|professional-code.")
   })
 })
 

--- a/models/errors/validation-errors.ts
+++ b/models/errors/validation-errors.ts
@@ -241,13 +241,12 @@ export const unexpectedField = (fhirPath: string): fhir.OperationOutcomeIssue =>
 
 export function createInvalidIdentifierIssue(
   resource: string,
-  incorrectIdentifier: string,
   acceptedList: string
 ): fhir.OperationOutcomeIssue {
   return {
     severity: "error",
     code: fhir.IssueCodes.VALUE,
     // eslint-disable-next-line max-len
-    diagnostics: `Expected ${resource}.identifier to contain more identifiers than ${incorrectIdentifier}. Also expected one of ${acceptedList}.`
+    diagnostics: `Bundle resource ${resource}.identifier expected exactly one professional code from ${acceptedList}.`
   }
 }


### PR DESCRIPTION
Chat with Ameya and Chris T, misunderstood that SDS User Identifier and DIN don't come under Professional Identifiers, so new expected behaviour is if there is a GMP under Practitioner.Identifier (regardless of whether there's other identifiers in there) then it should still throw the error to recommend a more suitable identifier.