### PR TITLE
AEA-2714 Removal logic for leading C's on GMC codes

### DIFF
--- a/coordinator/src/services/translation/request/practitioner.ts
+++ b/coordinator/src/services/translation/request/practitioner.ts
@@ -177,12 +177,15 @@ export function getAgentPersonPersonIdForAuthor(
 ): hl7V3.PrescriptionAuthorId {
   const professionalCode: Array<hl7V3.ProfessionalCode> = []
 
-  const gmcCode = getIdentifierValueOrNullForSystem(
+  let gmcCode = getIdentifierValueOrNullForSystem(
     fhirPractitionerIdentifier,
     "https://fhir.hl7.org.uk/Id/gmc-number",
     "Practitioner.identifier"
   )
   if (gmcCode) {
+    if(gmcCode.toUpperCase().startsWith("C")) {
+      gmcCode = gmcCode.substring(1)
+    }
     professionalCode.push(new hl7V3.ProfessionalCode(gmcCode))
   }
 

--- a/coordinator/tests/services/translation/request/practitioner.spec.ts
+++ b/coordinator/tests/services/translation/request/practitioner.spec.ts
@@ -64,14 +64,21 @@ describe("getAgentPersonTelecom", () => {
 })
 
 describe("getAgentPersonPersonIdForAuthor", () => {
+  const gmcCodeValue = "123425516"
+
   const gmcCode: fhir.Identifier = {
     "system": "https://fhir.hl7.org.uk/Id/gmc-number",
-    "value": "C1234567"
+    "value": `C${gmcCodeValue}`
   }
   const gmpCode : fhir.Identifier = {
     "system": "https://fhir.hl7.org.uk/Id/gmp-number",
     "value": "G1234567"
   }
+
+  test("Removes leading C from GMC code", () => {
+    expect(practitioner.getAgentPersonPersonIdForAuthor([gmcCode])._attributes.extension)
+      .toBe(gmcCodeValue)
+  })
 
   test("if more than 1 professional code is present for a practitioner then throw", () => {
     expect(() => practitioner.getAgentPersonPersonIdForAuthor(
@@ -84,8 +91,8 @@ describe("getAgentPersonPersonIdForAuthor", () => {
     )).toThrow()
   })
   test("if 1 professional code is present, then return it", () => {
-    expect(practitioner.getAgentPersonPersonIdForAuthor([gmcCode])._attributes.extension)
-      .toBe("C1234567")
+    expect(practitioner.getAgentPersonPersonIdForAuthor([gmpCode])._attributes.extension)
+      .toBe(gmpCode.value)
   })
 })
 

--- a/coordinator/tests/services/translation/request/practitioner.spec.ts
+++ b/coordinator/tests/services/translation/request/practitioner.spec.ts
@@ -64,7 +64,7 @@ describe("getAgentPersonTelecom", () => {
 })
 
 describe("getAgentPersonPersonIdForAuthor", () => {
-  const gmcCodeValue = "123425516"
+  const gmcCodeValue = "1234567"
 
   const gmcCode: fhir.Identifier = {
     "system": "https://fhir.hl7.org.uk/Id/gmc-number",


### PR DESCRIPTION
Used to have this functionality, got lost over the past 2 years, now adding it back