### PR TITLE
Ref rate limits

### DIFF
--- a/proxies/live/apiproxy/policies/Quota.xml
+++ b/proxies/live/apiproxy/policies/Quota.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Quota name="Quota" type="calendar">
     <DisplayName>Quota</DisplayName>
-    <Allow count="300" countRef="apiproduct.developer.quota.limit"/>
+    <Allow count="9600" countRef="apiproduct.developer.quota.limit"/>
     <Interval ref="apiproduct.developer.quota.interval">1</Interval>
     <TimeUnit ref="apiproduct.developer.quota.timeunit">minute</TimeUnit>
     <StartTime>2020-3-30 12:00:00</StartTime>

--- a/proxies/live/apiproxy/policies/SpikeArrest.xml
+++ b/proxies/live/apiproxy/policies/SpikeArrest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <SpikeArrest name="SpikeArrest">
   <DisplayName>SpikeArrest</DisplayName>
-  <Rate ref="apiproduct.ratelimit">5ps</Rate>
+  <Rate ref="apiproduct.ratelimit">160ps</Rate>
 </SpikeArrest>
 


### PR DESCRIPTION
Just a change to Quota.xml and SpikeArrest.xml which can act as a default to the rate limiting set in the manifest_template.yml for un-authenticated access.