### PR TITLE
AEA-2710 Disable verify-signature Pact tests for PTL envs

### DIFF
--- a/tests/e2e/pact/broker/verify.ts
+++ b/tests/e2e/pact/broker/verify.ts
@@ -57,7 +57,10 @@ async function verifyValidate(): Promise<void> {
 }
 
 async function verifyVerifySignatures(): Promise<void> {
-  await verifyOnce("verify-signature")
+  // AEA-2710 - Re-enable test for PTL once we're able to use/generate a signed prescription within Pact tests
+  if (process.env.SANDBOX === "1" || process.env.APIGEE_ENVIRONMENT === "internal-dev") {
+    await verifyOnce("verify-signature")
+  }
 }
 
 async function verifyPrepare(): Promise<void> {


### PR DESCRIPTION
Tests are failing because they require the prescriptions used to be present in INT and to have a valid signature.
Disabling the tests for PTL in order to unblock releases to INT and QA, as they will be addressed with future work on key fields comparison (AEA-2645).