### PR TITLE
AEA-2777 Create prescription for Spine tracker tests in CI

### DIFF
--- a/tests/e2e/pact/specs/live/tracker.spec.ts
+++ b/tests/e2e/pact/specs/live/tracker.spec.ts
@@ -28,25 +28,33 @@ const updateTestPrescriptions = async (): Promise<void> => {
   generateTestOutputFile()
 }
 
+const getTestCase = () => {
+  const testCase = TestResources.processOrderCases[0]
+  return {
+    caseDesc: testCase[0],
+    bundle: testCase[1]
+  }
+}
+
+const getPrescriptionShortFormId = (bundle: fhir.Bundle) => {
+  const firstMedicationRequest = bundle.entry.map(e => e.resource)
+    .find(r => r.resourceType === "MedicationRequest") as fhir.MedicationRequest
+  return firstMedicationRequest.groupIdentifier.value
+}
+
 describe("prescription tracker e2e test", async () => {
-  let prescriptionId: string
 
   beforeAll(async () => {
     updateTestPrescriptions()
   })
 
   test("is able to create a test prescription", async () => {
-    const testCase = TestResources.processOrderCases[0]
-    const caseDesc: string = testCase[0]
-    const bundle: fhir.Bundle = testCase[1]
-
     const options = new CreatePactOptions("live", "process", "send")
     const provider = new Pact(pactOptions(options))
     await provider.setup()
 
-    const firstMedicationRequest = bundle.entry.map(e => e.resource)
-      .find(r => r.resourceType === "MedicationRequest") as fhir.MedicationRequest
-    prescriptionId = firstMedicationRequest.groupIdentifier.value
+    const {caseDesc, bundle} = getTestCase()
+    const prescriptionId = getPrescriptionShortFormId(bundle)
 
     const interaction = createInteraction(
       options,
@@ -67,6 +75,10 @@ describe("prescription tracker e2e test", async () => {
     const interaction = createInteraction(
       createPactOptions
     )
+
+    const {bundle} = getTestCase()
+    const prescriptionId = getPrescriptionShortFormId(bundle)
+
     interaction.withRequest.query = {
       "prescription_id": prescriptionId,
       "repeat_number": "1"

--- a/tests/e2e/pact/specs/live/tracker.spec.ts
+++ b/tests/e2e/pact/specs/live/tracker.spec.ts
@@ -56,14 +56,15 @@ const sendTestPrescription = async (): Promise<string> => {
 }
 
 describe("prescription tracker e2e test", async () => {
-  let prescriptionId: string
 
   beforeAll(async () => {
     updateTestPrescriptions()
-    prescriptionId = await sendTestPrescription()
   })
 
   test("is able to retrieve prescription from Spine", async () => {
+    // Create prescription
+    const prescriptionId = await sendTestPrescription()
+
     const createPactOptions = new CreatePactOptions("live", "tracker")
     const provider = new Pact(pactOptions(createPactOptions))
     await provider.setup()

--- a/tests/e2e/pact/specs/live/tracker.spec.ts
+++ b/tests/e2e/pact/specs/live/tracker.spec.ts
@@ -1,18 +1,81 @@
-import {createInteraction, CreatePactOptions, pactOptions} from "../../resources/common"
+import {
+  createInteraction,
+  CreatePactOptions,
+  pactOptions,
+  successfulOperationOutcome
+} from "../../resources/common"
 import {Pact} from "@pact-foundation/pact"
+import {pino} from "pino"
+import {fhir, fetcher} from "@models"
+import * as TestResources from "../../resources/test-resources"
+import {updatePrescriptions} from "../../services/update-prescriptions"
+import {generateTestOutputFile} from "../../services/genereate-test-output-file"
 
-test("prescription tracker e2e test", async () => {
-  const createPactOptions = new CreatePactOptions("live", "tracker")
-  const provider = new Pact(pactOptions(createPactOptions))
-  await provider.setup()
-  const interaction = createInteraction(
-    createPactOptions
-  )
-  interaction.withRequest.query = {
-    "prescription_id": "EB8B1F-A83008-42DC8L",
-    "repeat_number": "1"
+const logger = pino()
+
+const updateTestPrescriptions = async (): Promise<void> => {
+  if (process.env.UPDATE_PRESCRIPTIONS !== "false") {
+    await updatePrescriptions(
+      fetcher.prescriptionOrderExamples.filter(e => e.isSuccess),
+      [],
+      [],
+      [],
+      [],
+      [],
+      logger
+    )
   }
+  generateTestOutputFile()
+}
+
+const sendTestPrescription = async (): Promise<string> => {
+  const testCase = TestResources.processOrderCases[0]
+  const caseDesc: string = testCase[0]
+  const bundle: fhir.Bundle = testCase[1]
+
+  const options = new CreatePactOptions("live", "process", "send")
+  const provider = new Pact(pactOptions(options))
+  await provider.setup()
+
+  const firstMedicationRequest = bundle.entry.map(e => e.resource)
+    .find(r => r.resourceType === "MedicationRequest") as fhir.MedicationRequest
+  const prescriptionId = firstMedicationRequest.groupIdentifier.value
+
+  const interaction = createInteraction(
+    options,
+    bundle,
+    successfulOperationOutcome,
+    `a request to process prescription: ${prescriptionId} - ${caseDesc} message to Spine`
+  )
+
   await provider.addInteraction(interaction)
   await provider.writePact()
   await provider.finalize()
+
+  return prescriptionId
+}
+
+describe("prescription tracker e2e test", async () => {
+  let prescriptionId: string
+
+  beforeAll(async () => {
+    updateTestPrescriptions()
+    prescriptionId = await sendTestPrescription()
+  })
+
+  test("is able to retrieve prescription from Spine", async () => {
+    const createPactOptions = new CreatePactOptions("live", "tracker")
+    const provider = new Pact(pactOptions(createPactOptions))
+    await provider.setup()
+    const interaction = createInteraction(
+      createPactOptions
+    )
+    interaction.withRequest.query = {
+      "prescription_id": prescriptionId,
+      "repeat_number": "1"
+    }
+    await provider.addInteraction(interaction)
+    await provider.writePact()
+    await provider.finalize()
+  })
 })


### PR DESCRIPTION
The Spine tracker Pact test is currently failing in Ref because the prescription does not exist.
This should fix the issue by creating a prescription at run time, which will be then retrieved by the test.