### PR TITLE
AEA-2826 Swapped rate limiting to use built-in APIM flow and switched to per minute spike arrest

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -13,20 +13,20 @@ APIGEE_ENVIRONMENTS:
   name: internal-qa-sandbox
 - display_name: Reference
   name: ref
-  ratelimit: 160ps
+  ratelimit: 9600pm
   quota: 9600
 - display_name: Sandbox
   name: sandbox
 - display_name: Integration Testing
   make_spec_visible: true
   name: int
-  ratelimit: 20ps
+  ratelimit: 1200pm
   quota: 1200
 - display_name: Production
   make_spec_visible: true
   name: prod
   approval_type: manual
-  ratelimit: 10ps
+  ratelimit: 1200pm
   quota: 1200
 
 PRODUCTS:
@@ -79,8 +79,19 @@ apigee:
         attributes:
           - name: access
             value: public
-          - name: ratelimit
-            value: {{ ENV.ratelimit | default('5ps') }}
+          - name: ratelimiting
+            value: 
+              {{ PRODUCT_NAME }}:
+                quota:
+                  limit: {{ ENV.quota | default(300)}}
+                  interval: 1
+                  timeunit: minute
+                  enabled: true
+                spikeArrest:
+                  # using per minute values because per second would cause 2 back to back requests to fail
+                  # (see https://docs.apigee.com/api-platform/reference/policies/spike-arrest-policy#expandable-1)
+                  ratelimit: {{ ENV.ratelimit | default('300pm') }}
+                  enabled: true
         description: {{ PRODUCT_DESCRIPTION }}
         displayName: {{ PRODUCT_TITLE }}
         environments: [ {{ ENV.name }} ]
@@ -95,9 +106,6 @@ apigee:
           - identity-service-mock-{{ ENV.name }}
 {% endif %}
         scopes: {{ PRODUCT.scopes }}
-        quota: {{ ENV.quota | default('300') }}
-        quotaInterval: '1'
-        quotaTimeUnit: minute
 {% endfor %}
     specs:
       - name: {{ API_NAME }}

--- a/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
+++ b/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
@@ -1,0 +1,4 @@
+<FlowCallout async="false" continueOnError="false" enabled="true" name="FlowCallout.ApplyRateLimiting">
+    <DisplayName>Apply Rate Limiting</DisplayName>
+    <SharedFlowBundle>ApplyRateLimiting</SharedFlowBundle>
+</FlowCallout>

--- a/proxies/live/apiproxy/policies/Quota.xml
+++ b/proxies/live/apiproxy/policies/Quota.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Quota name="Quota" type="calendar">
-    <DisplayName>Quota</DisplayName>
-    <Allow count="9600" countRef="apiproduct.developer.quota.limit"/>
-    <Interval ref="apiproduct.developer.quota.interval">1</Interval>
-    <TimeUnit ref="apiproduct.developer.quota.timeunit">minute</TimeUnit>
-    <StartTime>2020-3-30 12:00:00</StartTime>
-</Quota>

--- a/proxies/live/apiproxy/policies/SpikeArrest.xml
+++ b/proxies/live/apiproxy/policies/SpikeArrest.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<SpikeArrest name="SpikeArrest">
-  <DisplayName>SpikeArrest</DisplayName>
-  <Rate ref="apiproduct.ratelimit">160ps</Rate>
-</SpikeArrest>
-

--- a/proxies/live/apiproxy/targets/apim.xml
+++ b/proxies/live/apiproxy/targets/apim.xml
@@ -34,10 +34,7 @@
           <Condition>(not original-request-details.header.X-Request-ID ~~ "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")</Condition>
         </Step>
         <Step>
-          <Name>Quota</Name>
-        </Step>
-        <Step>
-          <Name>SpikeArrest</Name>
+          <Name>FlowCallout.ApplyRateLimiting</Name>
         </Step>
         <Step>
           <Name>FlowCallout.UserRoleService</Name>

--- a/proxies/live/apiproxy/targets/sync-wrap.xml
+++ b/proxies/live/apiproxy/targets/sync-wrap.xml
@@ -63,10 +63,7 @@
         <Name>OauthV2.VerifyAccessToken</Name>
       </Step>
       <Step>
-        <Name>Quota</Name>
-      </Step>
-      <Step>
-        <Name>SpikeArrest</Name>
+        <Name>FlowCallout.ApplyRateLimiting</Name>
       </Step>
       <Step>
         <Name>AssignMessage.AddSyncWaitHeader</Name>


### PR DESCRIPTION
(per second spike arrests are amortized over milliseconds whereas per minute spike arrests are amortized over seconds)