### PR TITLE
AEA-2644 Set tests authorisationExpiryDate to a date in the future

### DIFF
--- a/coordinator/tests/services/translation/request/prescription.spec.ts
+++ b/coordinator/tests/services/translation/request/prescription.spec.ts
@@ -1,3 +1,8 @@
+import moment from "moment"
+import pino from "pino"
+import {LosslessNumber} from "lossless-json"
+
+import {fhir, hl7V3} from "@models"
 import {addEmptyCommunicationRequestToBundle, addEmptyListToBundle, clone} from "../../../resources/test-helpers"
 import * as TestResources from "../../../resources/test-resources"
 import {
@@ -16,10 +21,8 @@ import {
 } from "../../../../src/services/translation/common/getResourcesOfType"
 import {getExtensionForUrl, toArray} from "../../../../src/services/translation/common"
 import {setCourseOfTherapyTypeCode} from "./course-of-therapy-type.spec"
-import {fhir, hl7V3} from "@models"
-import pino from "pino"
-import {LosslessNumber} from "lossless-json"
 import {InvalidValueError} from "../../../../../models/errors/processing-errors"
+import {convertMomentToISODate} from "../../../../src/services/translation/common/dateTime"
 
 const logger = pino()
 
@@ -312,9 +315,14 @@ describe("extractReviewDate returns the correct value", () => {
   })
 
   test("for a medication request with a review date", () => {
-    setReviewDate(medicationRequest, "2022-12-07")
+    // Dynamically set the date in the future, because
+    // authorisationExpiryDate cannot be in the past
+    const dateTomorrow = moment().add(1, "day")
+    const formattedDateTomorrow = convertMomentToISODate(dateTomorrow)
+    setReviewDate(medicationRequest, formattedDateTomorrow)
+
     const converted = extractReviewDate(medicationRequest)
-    expect(converted).toEqual("2022-12-07")
+    expect(converted).toEqual(formattedDateTomorrow)
   })
 
   test("for a medication request with repeat information but without a review date", () => {

--- a/examples/errors/2-Prepare-Request-400_Invalid_Course_of_Therapy_mixed.json
+++ b/examples/errors/2-Prepare-Request-400_Invalid_Course_of_Therapy_mixed.json
@@ -197,7 +197,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/errors/2-Process-Request-Send-400_Invalid_Course_of_Therapy_mixed.json
+++ b/examples/errors/2-Process-Request-Send-400_Invalid_Course_of_Therapy_mixed.json
@@ -197,7 +197,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/acute-and-repeat-prescribing/1-Prepare-Request-200_OK.json
+++ b/examples/primary-care/acute-and-repeat-prescribing/1-Prepare-Request-200_OK.json
@@ -197,7 +197,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/acute-and-repeat-prescribing/1-Process-Request-Send-200_OK.json
+++ b/examples/primary-care/acute-and-repeat-prescribing/1-Process-Request-Send-200_OK.json
@@ -197,7 +197,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/din/1-Convert-Response-Send-200_OK.xml
+++ b/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/din/1-Convert-Response-Send-200_OK.xml
@@ -204,7 +204,7 @@
               <seperatableInd value="false"/>
               <pertinentReviewDate classCode="OBS" moodCode="EVN">
                 <code code="RD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.30"/>
-                <value value="20221207"/>
+                <value value="20241130"/>
               </pertinentReviewDate>
             </pertinentInformation7>
             <pertinentInformation5 contextConductionInd="true" typeCode="PERT">

--- a/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/din/1-Prepare-Request-200_OK.json
+++ b/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/din/1-Prepare-Request-200_OK.json
@@ -71,7 +71,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -211,7 +211,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/din/1-Process-Request-Send-200_OK.json
+++ b/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/din/1-Process-Request-Send-200_OK.json
@@ -71,7 +71,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -211,7 +211,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/spurious-code/1-Convert-Response-Send-200_OK.xml
+++ b/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/spurious-code/1-Convert-Response-Send-200_OK.xml
@@ -204,7 +204,7 @@
               <seperatableInd value="false"/>
               <pertinentReviewDate classCode="OBS" moodCode="EVN">
                 <code code="RD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.30"/>
-                <value value="20221207"/>
+                <value value="20241130"/>
               </pertinentReviewDate>
             </pertinentInformation7>
             <pertinentInformation5 contextConductionInd="true" typeCode="PERT">

--- a/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/spurious-code/1-Prepare-Request-200_OK.json
+++ b/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/spurious-code/1-Prepare-Request-200_OK.json
@@ -71,7 +71,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -211,7 +211,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/spurious-code/1-Process-Request-Send-200_OK.json
+++ b/examples/primary-care/repeat-dispensing/nominated-pharmacy/medical-prescriber/author/gmc/responsible-party/medication-list/spurious-code/1-Process-Request-Send-200_OK.json
@@ -71,7 +71,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -211,7 +211,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/repeat-prescribing/1-Convert-Response-Send-200_OK.xml
+++ b/examples/primary-care/repeat-prescribing/1-Convert-Response-Send-200_OK.xml
@@ -191,7 +191,7 @@
               <seperatableInd value="false"/>
               <pertinentReviewDate classCode="OBS" moodCode="EVN">
                 <code code="RD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.30"/>
-                <value value="20221207"/>
+                <value value="20241130"/>
               </pertinentReviewDate>
             </pertinentInformation7>
             <pertinentInformation5 contextConductionInd="true" typeCode="PERT">

--- a/examples/primary-care/repeat-prescribing/1-Prepare-Request-200_OK.json
+++ b/examples/primary-care/repeat-prescribing/1-Prepare-Request-200_OK.json
@@ -90,7 +90,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -244,7 +244,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/primary-care/repeat-prescribing/1-Process-Request-Send-200_OK.json
+++ b/examples/primary-care/repeat-prescribing/1-Process-Request-Send-200_OK.json
@@ -90,7 +90,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -244,7 +244,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/non-prescriber-endorsed/1-Convert-Response-Send-200_OK.xml
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/non-prescriber-endorsed/1-Convert-Response-Send-200_OK.xml
@@ -199,7 +199,7 @@
               <seperatableInd value="false"/>
               <pertinentReviewDate classCode="OBS" moodCode="EVN">
                 <code code="RD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.30"/>
-                <value value="20221207"/>
+                <value value="20241130"/>
               </pertinentReviewDate>
             </pertinentInformation7>
             <pertinentInformation5 contextConductionInd="true" typeCode="PERT">

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/non-prescriber-endorsed/1-Prepare-Request-200_OK.json
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/non-prescriber-endorsed/1-Prepare-Request-200_OK.json
@@ -68,7 +68,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -234,7 +234,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -400,7 +400,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -566,7 +566,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/non-prescriber-endorsed/1-Process-Request-Send-200_OK.json
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/non-prescriber-endorsed/1-Process-Request-Send-200_OK.json
@@ -68,7 +68,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -234,7 +234,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -400,7 +400,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }
@@ -566,7 +566,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/prescriber-endorsed/1-Convert-Response-Send-200_OK.xml
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/prescriber-endorsed/1-Convert-Response-Send-200_OK.xml
@@ -199,7 +199,7 @@
               <seperatableInd value="false"/>
               <pertinentReviewDate classCode="OBS" moodCode="EVN">
                 <code code="RD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.30"/>
-                <value value="20221207"/>
+                <value value="20241130"/>
               </pertinentReviewDate>
             </pertinentInformation7>
             <pertinentInformation5 contextConductionInd="true" typeCode="PERT">

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/prescriber-endorsed/1-Prepare-Request-200_OK.json
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/prescriber-endorsed/1-Prepare-Request-200_OK.json
@@ -68,7 +68,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },
@@ -246,7 +246,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },
@@ -424,7 +424,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },
@@ -602,7 +602,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/prescriber-endorsed/1-Process-Request-Send-200_OK.json
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/multiple-medication-requests/prescriber-endorsed/1-Process-Request-Send-200_OK.json
@@ -68,7 +68,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },
@@ -246,7 +246,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },
@@ -424,7 +424,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },
@@ -602,7 +602,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           },

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/single-medication-request/1-Convert-Response-Send-200_OK.xml
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/single-medication-request/1-Convert-Response-Send-200_OK.xml
@@ -199,7 +199,7 @@
               <seperatableInd value="false"/>
               <pertinentReviewDate classCode="OBS" moodCode="EVN">
                 <code code="RD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.30"/>
-                <value value="20221207"/>
+                <value value="20241130"/>
               </pertinentReviewDate>
             </pertinentInformation7>
             <pertinentInformation5 contextConductionInd="true" typeCode="PERT">

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/single-medication-request/1-Prepare-Request-200_OK.json
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/single-medication-request/1-Prepare-Request-200_OK.json
@@ -68,7 +68,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/single-medication-request/1-Process-Request-Send-200_OK.json
+++ b/examples/secondary-care/community/repeat-dispensing/nominated-pharmacy/clinical-practitioner/single-medication-request/1-Process-Request-Send-200_OK.json
@@ -68,7 +68,7 @@
             "extension": [
               {
                 "url": "authorisationExpiryDate",
-                "valueDateTime": "2022-12-07"
+                "valueDateTime": "2024-11-30"
               }
             ]
           }

--- a/specification/schemas/MedicationRequest/extensions/MedicationRepeatInformation.yaml
+++ b/specification/schemas/MedicationRequest/extensions/MedicationRepeatInformation.yaml
@@ -23,4 +23,4 @@ properties:
         valueDateTime:
           type: string
           description: A date value
-          example: "2022-12-07"
+          example: "2024-11-30"


### PR DESCRIPTION
The date for authorisationExpiryDate is now a value in the past, so tests started failing.
A search and replace is the quick solution and fixes the issue for a couple of years.