### PR TITLE
AEA-2650 Refactor Spine response translation to async

### DIFF
--- a/packages/coordinator/jest.config.js
+++ b/packages/coordinator/jest.config.js
@@ -26,5 +26,5 @@ module.exports = {
   // Fix for: "Emitted 'error' event on ChildProcess instance at"
   // https://github.com/facebook/jest/issues/10144
   // https://jestjs.io/docs/cli#--maxworkersnumstring
-  maxWorkers: "50%",
+  maxWorkers: 2,
 }

--- a/packages/coordinator/jest.config.js
+++ b/packages/coordinator/jest.config.js
@@ -14,12 +14,17 @@ module.exports = {
   ],
   moduleNameMapper: {
     "@models": "<rootDir>../models",
-
+    
     // lossless-json is now published with both ESM and CommonJS exports.
     // Because Jest runs code in Node, we have to force it to
     // use the CommonJS import.
     // Source (actually from axios, not lossless-json):
     // https://github.com/axios/axios/issues/5101#issuecomment-1276572468
     "^lossless-json$": require.resolve("lossless-json")
-  }
+  },
+
+  // Fix for: "Emitted 'error' event on ChildProcess instance at"
+  // https://github.com/facebook/jest/issues/10144
+  // https://jestjs.io/docs/cli#--maxworkersnumstring
+  maxWorkers: "50%",
 }

--- a/packages/coordinator/src/routes/dispense/claim.ts
+++ b/packages/coordinator/src/routes/dispense/claim.ts
@@ -46,7 +46,7 @@ export default [
         logger.info("Building Spine claim request")
         const spineRequest = translator.convertClaimToSpineRequest(claimPayload, request.headers, logger)
         const spineResponse = await spineClient.send(spineRequest, request.logger)
-        return handleResponse(request, spineResponse, responseToolkit)
+        return await handleResponse(request, spineResponse, responseToolkit)
       }
     )
   }

--- a/packages/coordinator/src/routes/dispense/release.ts
+++ b/packages/coordinator/src/routes/dispense/release.ts
@@ -46,7 +46,7 @@ export default [
         logger.info("Building Spine release request")
         const spineRequest = translator.convertParametersToSpineRequest(parameters, request.headers, logger)
         const spineResponse = await spineClient.send(spineRequest, request.logger)
-        return handleResponse(request, spineResponse, responseToolkit)
+        return await handleResponse(request, spineResponse, responseToolkit)
       }
     )
   }

--- a/packages/coordinator/src/routes/dispense/task.ts
+++ b/packages/coordinator/src/routes/dispense/task.ts
@@ -41,7 +41,7 @@ export default [
         logger.info("Building Spine return / withdraw request")
         const spineRequest = translator.convertTaskToSpineRequest(taskPayload, request.headers, logger)
         const spineResponse = await spineClient.send(spineRequest, request.logger)
-        return handleResponse(request, spineResponse, responseToolkit)
+        return await handleResponse(request, spineResponse, responseToolkit)
       }
     )
   }

--- a/packages/coordinator/src/routes/dispense/verify-signature.ts
+++ b/packages/coordinator/src/routes/dispense/verify-signature.ts
@@ -44,8 +44,10 @@ const verifyPrescription = async (
   const fhirPrescriptionTranslatedFromHl7v3 = createBundle(hl7v3PrescriptionFromTracker, "")
   const prescriptionFromTracker = common.buildPrescription(fhirPrescriptionTranslatedFromHl7v3)
   const prescriptionFromRequest = common.buildPrescription(fhirPrescriptionFromRequest)
+
+  const signatureVerificationErrors = await verifyPrescriptionSignature(hl7v3PrescriptionFromTracker, logger)
   const errors = [
-    ...verifyPrescriptionSignature(hl7v3PrescriptionFromTracker, logger),
+    ...signatureVerificationErrors,
     ...comparePrescriptions(prescriptionFromTracker, prescriptionFromRequest)
   ]
   if (errors.length) {

--- a/packages/coordinator/src/routes/polling.ts
+++ b/packages/coordinator/src/routes/polling.ts
@@ -13,6 +13,6 @@ export default [{
       getAsid(request.headers),
       request.logger
     )
-    return handleResponse(request, spineResponse, responseToolkit)
+    return await handleResponse(request, spineResponse, responseToolkit)
   }
 }]

--- a/packages/coordinator/src/routes/process.ts
+++ b/packages/coordinator/src/routes/process.ts
@@ -40,7 +40,7 @@ export default [
         request.logger.info("Building Spine request")
         const spineRequest = await translator.convertBundleToSpineRequest(bundle, request.headers, request.logger)
         const spineResponse = await spineClient.send(spineRequest, request.logger)
-        return handleResponse(request, spineResponse, responseToolkit)
+        return await handleResponse(request, spineResponse, responseToolkit)
       }
     )
   }

--- a/packages/coordinator/src/routes/util.ts
+++ b/packages/coordinator/src/routes/util.ts
@@ -31,26 +31,26 @@ export function createHash(thingsToHash: string): string {
   return crypto.SHA256(thingsToHash).toString()
 }
 
-export function handleResponse<T>(
+export async function handleResponse<T>(
   request: Hapi.Request,
   spineResponse: spine.SpineDirectResponse<T> | spine.SpinePollableResponse,
   responseToolkit: Hapi.ResponseToolkit
-): Hapi.ResponseObject {
-  if (spine.isPollable(spineResponse)) {
+): Promise<Hapi.ResponseObject> {
+  if (spine.isPollable(spineResponse)) { // Spine pollable response
     return responseToolkit.response()
       .code(spineResponse.statusCode)
       .header("Content-Location", spineResponse.pollingUrl)
-  } else if (isOperationOutcome(spineResponse.body) || isBundle(spineResponse.body)) {
+  } else if (isOperationOutcome(spineResponse.body) || isBundle(spineResponse.body)) { // FHIR response
     return responseToolkit.response(spineResponse.body)
       .code(spineResponse.statusCode)
       .type(ContentTypes.FHIR)
   } else {
-    if (request.headers[RequestHeaders.RAW_RESPONSE]) {
+    if (request.headers[RequestHeaders.RAW_RESPONSE]) { // Return XML Spine response
       return responseToolkit
         .response(spineResponse.body.toString())
         .code(200)
         .type(ContentTypes.XML)
-    } else {
+    } else { // Translate Spine response to FHIR message
       const translatedSpineResponse = translateToFhir(spineResponse, request.logger, request.headers)
       const serializedResponse = LosslessJson.stringify(translatedSpineResponse.fhirResponse)
       return responseToolkit.response(serializedResponse)

--- a/packages/coordinator/src/routes/util.ts
+++ b/packages/coordinator/src/routes/util.ts
@@ -51,7 +51,7 @@ export async function handleResponse<T>(
         .code(200)
         .type(ContentTypes.XML)
     } else { // Translate Spine response to FHIR message
-      const translatedSpineResponse = translateToFhir(spineResponse, request.logger, request.headers)
+      const translatedSpineResponse = await translateToFhir(spineResponse, request.logger, request.headers)
       const serializedResponse = LosslessJson.stringify(translatedSpineResponse.fhirResponse)
       return responseToolkit.response(serializedResponse)
         .code(translatedSpineResponse.statusCode)

--- a/packages/coordinator/src/services/translation/request/return/return-factory.ts
+++ b/packages/coordinator/src/services/translation/request/return/return-factory.ts
@@ -14,12 +14,10 @@ import {
 } from "../../../../../../models/hl7-v3"
 
 type response = PrescriptionReleaseResponse
-
 type ReturnProposal = DispenseProposalReturnRoot
 
 export interface ReturnFactory {
   create(response: response, returnReasonCode: ReturnReasonCode): ReturnProposal
-  create(response: PrescriptionReleaseResponse, returnReasonCode: ReturnReasonCode): DispenseProposalReturnRoot
 }
 
 export class DispenseProposalReturnFactory implements ReturnFactory {

--- a/packages/coordinator/src/services/translation/response/index.ts
+++ b/packages/coordinator/src/services/translation/response/index.ts
@@ -39,12 +39,13 @@ export function createReleaseHandlers(requestHeaders: Hapi.Util.Dictionary<strin
   ]
 }
 
-export function translateToFhir<T>(
+export async function translateToFhir<T>(
   hl7Message: spine.SpineDirectResponse<T>,
   logger: pino.Logger,
-  requestHeaders: Hapi.Util.Dictionary<string>): TranslatedSpineResponse {
+  requestHeaders: Hapi.Util.Dictionary<string>): Promise<TranslatedSpineResponse> {
   const responseHandlers = [...createReleaseHandlers(requestHeaders), ...spineResponseHandlers]
   const bodyString = hl7Message.body.toString()
+
   for (const handler of responseHandlers) {
     const translatedSpineResponse = handler.handleResponse(bodyString, logger)
     if (translatedSpineResponse) {

--- a/packages/coordinator/src/services/translation/response/index.ts
+++ b/packages/coordinator/src/services/translation/response/index.ts
@@ -47,7 +47,7 @@ export async function translateToFhir<T>(
   const bodyString = hl7Message.body.toString()
 
   for (const handler of responseHandlers) {
-    const translatedSpineResponse = handler.handleResponse(bodyString, logger)
+    const translatedSpineResponse = await handler.handleResponse(bodyString, logger)
     if (translatedSpineResponse) {
       return translatedSpineResponse
     }

--- a/packages/coordinator/src/services/translation/response/release/release-response.ts
+++ b/packages/coordinator/src/services/translation/response/release/release-response.ts
@@ -69,11 +69,11 @@ export type TranslationResponseResult = {
   dispenseProposalReturns: Array<DispenseProposalReturnRoot>
 }
 
-export function translateReleaseResponse(
+export async function translateReleaseResponse(
   releaseResponse: hl7V3.PrescriptionReleaseResponse,
   logger: pino.Logger,
   returnFactory: ReturnFactory
-): TranslationResponseResult {
+): Promise<TranslationResponseResult> {
   const releaseRequestId = releaseResponse.inFulfillmentOf.priorDownloadRequestRef.id._attributes.root
   const result = toArray(releaseResponse.component)
     .filter(component => component.templateId._attributes.extension === SUPPORTED_MESSAGE_TYPE)

--- a/packages/coordinator/src/services/translation/response/release/release-response.ts
+++ b/packages/coordinator/src/services/translation/response/release/release-response.ts
@@ -12,7 +12,7 @@ import {ReturnFactory} from "../../request/return/return-factory"
 // Rob Gooch - We can go with just PORX_MT122003UK32 as UK30 prescriptions are not signed
 // so not legal electronic prescriptions
 const SUPPORTED_MESSAGE_TYPE = "PORX_MT122003UK32"
-const isPrescriptionTypeSupported = (component: hl7V3.PrescriptionReleaseResponseComponent): boolean => {
+const isSupportedMessageType = (component: hl7V3.PrescriptionReleaseResponseComponent): boolean => {
   return component.templateId._attributes.extension === SUPPORTED_MESSAGE_TYPE
 }
 
@@ -93,9 +93,9 @@ export async function translateReleaseResponse(
   const dispenseProposalReturns: Array<hl7V3.DispenseProposalReturnRoot> = []
 
   const releaseRequestId = releaseResponse.inFulfillmentOf.priorDownloadRequestRef.id._attributes.root
-  const supportedPrescriptions = toArray(releaseResponse.component).filter(isPrescriptionTypeSupported)
+  const supportedMessages = toArray(releaseResponse.component).filter(isSupportedMessageType)
 
-  for (const component of supportedPrescriptions) {
+  for (const component of supportedMessages) {
     const bundle = createInnerBundle(component.ParentPrescription, releaseRequestId)
     const errors = await verifyPrescriptionSignature(component.ParentPrescription, logger)
 

--- a/packages/coordinator/src/services/translation/response/spine-response-handler.ts
+++ b/packages/coordinator/src/services/translation/response/spine-response-handler.ts
@@ -26,7 +26,7 @@ export class SpineResponseHandler<T> {
     this.regex = new RegExp(pattern)
   }
 
-  handleResponse(spineResponse: string, logger: pino.Logger): TranslatedSpineResponse {
+  async handleResponse(spineResponse: string, logger: pino.Logger): Promise<TranslatedSpineResponse> {
     const sendMessagePayload = this.extractSendMessagePayload(spineResponse)
     if (!sendMessagePayload) {
       return null

--- a/packages/coordinator/src/services/translation/response/spine-response-handler.ts
+++ b/packages/coordinator/src/services/translation/response/spine-response-handler.ts
@@ -34,7 +34,7 @@ export class SpineResponseHandler<T> {
     const acknowledgementTypeCode = this.extractAcknowledgementTypeCode(sendMessagePayload)
     switch (acknowledgementTypeCode) {
       case hl7V3.AcknowledgementTypeCode.ACKNOWLEDGED:
-        return this.handleSuccessResponse(sendMessagePayload, logger)
+        return await this.handleSuccessResponse(sendMessagePayload, logger)
       case hl7V3.AcknowledgementTypeCode.ERROR:
       case hl7V3.AcknowledgementTypeCode.ERROR_ALTERNATIVE:
         return this.handleErrorResponse(sendMessagePayload, logger)
@@ -474,10 +474,10 @@ export class SpineResponseHandler<T> {
   }
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  protected handleSuccessResponse(
+  protected async handleSuccessResponse(
     sendMessagePayload: hl7V3.SendMessagePayload<T>,
     logger: pino.Logger
-  ): TranslatedSpineResponse {
+  ): Promise<TranslatedSpineResponse> {
     return SpineResponseHandler.createSuccessResponse()
   }
 }
@@ -494,9 +494,9 @@ export class CancelResponseHandler extends SpineResponseHandler<hl7V3.Cancellati
     this.translator = translator
   }
 
-  protected handleSuccessResponse(
+  protected async handleSuccessResponse(
     sendMessagePayload: hl7V3.SendMessagePayload<hl7V3.CancellationResponseRoot>
-  ): TranslatedSpineResponse {
+  ): Promise<TranslatedSpineResponse> {
     const cancellationResponse = sendMessagePayload.ControlActEvent.subject.CancellationResponse
     return {
       statusCode: 200,
@@ -537,10 +537,11 @@ export class ReleaseResponseHandler extends SpineResponseHandler<hl7V3.Prescript
     this.dispensePurposalReturnFactory = dispenseReturnFactory,
     this.releaseReturnHandler = releaseReturnHandler
   }
-  protected handleSuccessResponse(
+
+  protected async handleSuccessResponse(
     sendMessagePayload: hl7V3.SendMessagePayload<hl7V3.PrescriptionReleaseResponseRoot>,
     logger: pino.Logger
-  ): TranslatedSpineResponse {
+  ): Promise<TranslatedSpineResponse> {
     const releaseResponse = sendMessagePayload.ControlActEvent.subject.PrescriptionReleaseResponse
     const translationResponseResult = this.translator(releaseResponse, logger, this.dispensePurposalReturnFactory)
 

--- a/packages/coordinator/src/services/verification/signature-verification.ts
+++ b/packages/coordinator/src/services/verification/signature-verification.ts
@@ -9,10 +9,10 @@ import {isTruthy} from "../translation/common"
 import {isSignatureCertificateValid} from "./certificate-revocation"
 import {convertHL7V3DateTimeToIsoDateTimeString, isDateInRange} from "../translation/common/dateTime"
 
-const verifyPrescriptionSignature = (
+const verifyPrescriptionSignature = async (
   parentPrescription: hl7V3.ParentPrescription,
   logger: pino.Logger
-): Array<string> => {
+): Promise<Array<string>> => {
   const validSignatureFormat = verifySignatureHasCorrectFormat(parentPrescription)
   if (!validSignatureFormat) {
     return ["Invalid signature format"]
@@ -30,9 +30,7 @@ const verifyPrescriptionSignature = (
     errors.push("Signature doesn't match prescription")
   }
 
-  // Note: resolving the promise manually to avoid refactoring all the
-  // functions that use 'verifyPrescriptionSignature'
-  const isCertificateValid = isSignatureCertificateValid(parentPrescription, logger)
+  const isCertificateValid = await isSignatureCertificateValid(parentPrescription, logger)
   if (!isCertificateValid) {
     errors.push("Certificate is revoked")
   }

--- a/packages/coordinator/src/services/verification/signature-verification.ts
+++ b/packages/coordinator/src/services/verification/signature-verification.ts
@@ -32,18 +32,10 @@ const verifyPrescriptionSignature = (
 
   // Note: resolving the promise manually to avoid refactoring all the
   // functions that use 'verifyPrescriptionSignature'
-  isSignatureCertificateValid(parentPrescription, logger).then((isValid) => {
-    if (!isValid) {
-      errors.push("Certificate is revoked")
-    }
-  }).catch((reason) => {
-    // Check if reason is defined and can be cast to a string
-    const hasLoggableReason = reason && reason as string
-    const prescriptionId = parentPrescription.id._attributes.root
-    let eMsg = `Failed to check certificate revocation for prescription '${prescriptionId}'`
-    if (hasLoggableReason) eMsg += `: ${reason}`
-    logger.error(eMsg)
-  })
+  const isCertificateValid = isSignatureCertificateValid(parentPrescription, logger)
+  if (!isCertificateValid) {
+    errors.push("Certificate is revoked")
+  }
 
   const verifyCertificateErrors = verifyCertificate(parentPrescription)
   if (verifyCertificateErrors.length > 0) {

--- a/packages/coordinator/tests/routes/util.spec.ts
+++ b/packages/coordinator/tests/routes/util.spec.ts
@@ -62,7 +62,7 @@ function createRoute<T>(spineResponse: spine.SpineDirectResponse<T> | spine.Spin
     method: "POST",
     path: "/test",
     handler: async (request, responseToolkit) => {
-      return handleResponse(request, spineResponse, responseToolkit)
+      return await handleResponse(request, spineResponse, responseToolkit)
     }
   }
 }

--- a/packages/coordinator/tests/services/translation/response/release/release-response.spec.ts
+++ b/packages/coordinator/tests/services/translation/response/release/release-response.spec.ts
@@ -103,11 +103,7 @@ describe("outer bundle", () => {
     })
 
     test("does not log any errors", () => {
-      // Despite the test using a valid release response, the certificate within the signature
-      // does not have a CRL Distribution Point, so we expect this test to only log this:
-      const expectedErrorLog = "Cannot retrieve CRL distribution point from certificate with serial 1b"
-      expect(loggerSpy).toHaveBeenCalledWith(expectedErrorLog)
-      expect(loggerSpy).toHaveBeenCalledTimes(1)
+      expect(loggerSpy).toHaveBeenCalledTimes(0)
     })
 
     test("verify factory to create dispenseProposalReturn is not called", () => {

--- a/packages/coordinator/tests/services/translation/response/release/release-response.spec.ts
+++ b/packages/coordinator/tests/services/translation/response/release/release-response.spec.ts
@@ -205,7 +205,7 @@ describe("outer bundle", () => {
     describe("operation outcome", () => {
       let operationOutcome: fhir.OperationOutcome
 
-      beforeAll(() => {
+      beforeAll(async () => {
         operationOutcome = prescriptions.entry[0].resource as fhir.OperationOutcome
       })
 

--- a/packages/coordinator/tests/services/translation/response/spine-response-handler.spec.ts
+++ b/packages/coordinator/tests/services/translation/response/spine-response-handler.spec.ts
@@ -38,20 +38,20 @@ describe("default handler", () => {
     expect(expectedSendMessagePayload).toMatchObject(actualSendMessagePayload)
   })
 
-  test("handleResponse returns null if spine response doesn't match regex", () => {
+  test("handleResponse returns null if spine response doesn't match regex", async () => {
     const expectedSendMessagePayload = createSuccess("MCCI_IN010000UK13", undefined)
     const spineResponse = writeXmlStringPretty({MCCI_SOMETHING_ELSE: expectedSendMessagePayload})
-    const result = defaultHandler.handleResponse(spineResponse, logger)
+    const result = await defaultHandler.handleResponse(spineResponse, logger)
     expect(result).toBeNull()
   })
 
-  function checkResponseObjectAndStatusCode(
+  async function checkResponseObjectAndStatusCode(
     expectedSendMessagePayload: hl7V3.SendMessagePayload<unknown>,
     expectedIssueArray: Array<fhir.OperationOutcomeIssue>,
     statusCode: number
   ) {
     const spineResponse = writeXmlStringPretty({MCCI_IN010000UK13: expectedSendMessagePayload})
-    const result = defaultHandler.handleResponse(spineResponse, logger)
+    const result = await defaultHandler.handleResponse(spineResponse, logger)
     expect(result).toMatchObject({
       statusCode: statusCode,
       fhirResponse: {
@@ -61,19 +61,19 @@ describe("default handler", () => {
     })
   }
 
-  test("handleResponse returns 500 response if spine response has invalid acknowledgement type code", () => {
+  test("handleResponse returns 500 response if spine response has invalid acknowledgement type code", async () => {
     const expectedSendMessagePayload = createUnhandled("MCCI_IN010000UK13")
     const expectedIssueArray: Array<fhir.OperationOutcomeIssue> = [{code: fhir.IssueCodes.INVALID, severity: "error"}]
-    checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 500)
+    await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 500)
   })
 
-  test("handleResponse returns 500 response if spine response is a rejection and detail is missing", () => {
+  test("handleResponse returns 500 response if spine response is a rejection and detail is missing", async () => {
     const expectedSendMessagePayload = createRejection("MCCI_IN010000UK13")
     const expectedIssueArray: Array<fhir.OperationOutcomeIssue> = [{code: fhir.IssueCodes.INVALID, severity: "error"}]
-    checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 500)
+    await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 500)
   })
 
-  test("handleResponse returns 400 response if spine response is a rejection (single detail)", () => {
+  test("handleResponse returns 400 response if spine response is a rejection (single detail)", async () => {
     const expectedSendMessagePayload = createRejection(
       "MCCI_IN010000UK13",
       createAcknowledgementDetail("RejectionCode", "Rejection Display Name")
@@ -81,10 +81,10 @@ describe("default handler", () => {
     const expectedIssueArray = [
       createErrorOperationOutcomeIssue(fhir.IssueCodes.INVALID, "RejectionCode", "Rejection Display Name")
     ]
-    checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
+    await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
   })
 
-  test("handleResponse returns 400 response if spine response is a rejection (multiple details)", () => {
+  test("handleResponse returns 400 response if spine response is a rejection (multiple details)", async () => {
     const expectedSendMessagePayload = createRejection(
       "MCCI_IN010000UK13",
       createAcknowledgementDetail("RejectionCode1", "Rejection Display Name 1"),
@@ -94,13 +94,13 @@ describe("default handler", () => {
       createErrorOperationOutcomeIssue(fhir.IssueCodes.INVALID, "RejectionCode1", "Rejection Display Name 1"),
       createErrorOperationOutcomeIssue(fhir.IssueCodes.INVALID, "RejectionCode2", "Rejection Display Name 2")
     ]
-    checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
+    await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
   })
 
-  test("handleResponse returns 500 response if spine response is an error and reason is missing", () => {
+  test("handleResponse returns 500 response if spine response is an error and reason is missing", async () => {
     const expectedSendMessagePayload = createError("MCCI_IN010000UK13", undefined)
     const expectedIssueArray: Array<fhir.OperationOutcomeIssue> = [{code: fhir.IssueCodes.INVALID, severity: "error"}]
-    checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 500)
+    await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 500)
   })
 
   const defaultErrorCases = [
@@ -110,7 +110,7 @@ describe("default handler", () => {
   ]
 
   test.each(defaultErrorCases)("handleResponse returns 400 response if spine response is a %p error (single reason)",
-    (_, codeSystem: string, spineErrorCode: string, translatedErrorCode: string) => {
+    async (_, codeSystem: string, spineErrorCode: string, translatedErrorCode: string) => {
       const expectedSendMessagePayload = createError(
         "MCCI_IN010000UK13",
         undefined,
@@ -119,11 +119,11 @@ describe("default handler", () => {
       const expectedIssueArray = [
         createErrorOperationOutcomeIssue(fhir.IssueCodes.INVALID, translatedErrorCode, "Error Display Name")
       ]
-      checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
+      await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
     })
 
   test.each(defaultErrorCases)("handleResponse returns 400 response if spine response is a %p error (multiple reasons)",
-    (_, codeSystem: string, spineErrorCode: string, translatedErrorCode: string) => {
+    async (_, codeSystem: string, spineErrorCode: string, translatedErrorCode: string) => {
       const expectedSendMessagePayload = createError(
         "MCCI_IN010000UK13",
         undefined,
@@ -134,7 +134,7 @@ describe("default handler", () => {
         createErrorOperationOutcomeIssue(fhir.IssueCodes.INVALID, translatedErrorCode, "Error Display Name 1"),
         createErrorOperationOutcomeIssue(fhir.IssueCodes.INVALID, translatedErrorCode, "Error Display Name 2")
       ]
-      checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
+      await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
     })
 
   const specificErrorCases = [
@@ -144,7 +144,7 @@ describe("default handler", () => {
   ]
 
   test.each(specificErrorCases)("handleResponse correctly translates '0001' %p error codes",
-    (_, codeSystem: string, translatedErrorCode: string, translatedErrorMessage: string) => {
+    async (_, codeSystem: string, translatedErrorCode: string, translatedErrorMessage: string) => {
       const expectedSendMessagePayload = createError(
         "MCCI_IN010000UK13",
         undefined,
@@ -158,16 +158,16 @@ describe("default handler", () => {
           translatedErrorMessage,
           "https://fhir.nhs.uk/CodeSystem/EPS-IssueCode")
       ]
-      checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
+      await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 400)
     })
 
-  test("handleResponse returns 200 response if spine response is a success", () => {
+  test("handleResponse returns 200 response if spine response is a success", async () => {
     const expectedSendMessagePayload = createSuccess("MCCI_IN010000UK13", undefined)
     const expectedIssueArray: Array<fhir.OperationOutcomeIssue> = [{
       code: fhir.IssueCodes.INFORMATIONAL,
       severity: "information"
     }]
-    checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 200)
+    await checkResponseObjectAndStatusCode(expectedSendMessagePayload, expectedIssueArray, 200)
   })
 })
 
@@ -191,19 +191,19 @@ describe("custom response handler", () => {
 
   const customHandler = new customHandlerClass("MCCI_IN010000UK13")
 
-  test("handleResponse calls rejection override if spine response is a rejection", () => {
+  test("handleResponse calls rejection override if spine response is a rejection", async () => {
     const expectedSendMessagePayload = createRejection(
       "MCCI_IN010000UK13",
       createAcknowledgementDetail("RejectionCode", "Rejection Display Name")
     )
     const spineResponse = writeXmlStringPretty({MCCI_IN010000UK13: expectedSendMessagePayload})
     rejectionOverride.mockReturnValueOnce(customResponse)
-    const result = customHandler.handleResponse(spineResponse, logger)
+    const result = await customHandler.handleResponse(spineResponse, logger)
     expect(result).toBe(customResponse)
     expect(rejectionOverride).toHaveBeenCalled()
   })
 
-  test("handleResponse calls error override if spine response is an error", () => {
+  test("handleResponse calls error override if spine response is an error", async () => {
     const expectedSendMessagePayload = createError(
       "MCCI_IN010000UK13",
       undefined,
@@ -211,16 +211,16 @@ describe("custom response handler", () => {
     )
     const spineResponse = writeXmlStringPretty({MCCI_IN010000UK13: expectedSendMessagePayload})
     errorOverride.mockReturnValueOnce(customResponse)
-    const result = customHandler.handleResponse(spineResponse, logger)
+    const result = await customHandler.handleResponse(spineResponse, logger)
     expect(result).toBe(customResponse)
     expect(errorOverride).toHaveBeenCalled()
   })
 
-  test("handleResponse calls success override if spine response is a success", () => {
+  test("handleResponse calls success override if spine response is a success", async () => {
     const expectedSendMessagePayload = createSuccess("MCCI_IN010000UK13", undefined)
     const spineResponse = writeXmlStringPretty({MCCI_IN010000UK13: expectedSendMessagePayload})
     successOverride.mockReturnValueOnce(customResponse)
-    const result = customHandler.handleResponse(spineResponse, logger)
+    const result = await customHandler.handleResponse(spineResponse, logger)
     expect(result).toBe(customResponse)
     expect(successOverride).toHaveBeenCalled()
   })
@@ -235,13 +235,13 @@ describe("cancel response handler", () => {
     resourceType: "Bundle"
   }
 
-  test("handleResponse returns 400 response if spine response is a rejection", () => {
+  test("handleResponse returns 400 response if spine response is a rejection", async () => {
     const expectedSendMessagePayload = createRejection(
       "PORX_IN050101UK31",
       createAcknowledgementDetail("RejectionCode", "Rejection Display Name")
     )
     const spineResponse = writeXmlStringPretty({PORX_IN050101UK31: expectedSendMessagePayload})
-    const result = cancelResponseHandler.handleResponse(spineResponse, logger)
+    const result = await cancelResponseHandler.handleResponse(spineResponse, logger)
     expect(result).toMatchObject({
       statusCode: 400,
       fhirResponse: {
@@ -251,7 +251,7 @@ describe("cancel response handler", () => {
     })
   })
 
-  test("handleResponse returns 400 response if spine response is an error", () => {
+  test("handleResponse returns 400 response if spine response is an error", async () => {
     const expectedSendMessagePayload = createError(
       "PORX_IN050101UK31",
       mockCancellationResponseRoot,
@@ -259,7 +259,7 @@ describe("cancel response handler", () => {
     )
     const spineResponse = writeXmlStringPretty({PORX_IN050101UK31: expectedSendMessagePayload})
     mockTranslator.mockReturnValueOnce(mockTranslatorResponse)
-    const result = cancelResponseHandler.handleResponse(spineResponse, logger)
+    const result = await cancelResponseHandler.handleResponse(spineResponse, logger)
     expect(result).toEqual({
       statusCode: 400,
       fhirResponse: mockTranslatorResponse
@@ -267,14 +267,14 @@ describe("cancel response handler", () => {
     expect(mockTranslator).toHaveBeenCalledWith(mockCancellationResponse)
   })
 
-  test("handleResponse returns 200 response if spine response is a success", () => {
+  test("handleResponse returns 200 response if spine response is a success", async () => {
     const expectedSendMessagePayload = createSuccess(
       "PORX_IN050101UK31",
       mockCancellationResponseRoot
     )
     const spineResponse = writeXmlStringPretty({PORX_IN050101UK31: expectedSendMessagePayload})
     mockTranslator.mockReturnValueOnce(mockTranslatorResponse)
-    const result = cancelResponseHandler.handleResponse(spineResponse, logger)
+    const result = await cancelResponseHandler.handleResponse(spineResponse, logger)
     expect(result).toEqual({
       statusCode: 200,
       fhirResponse: mockTranslatorResponse
@@ -302,13 +302,13 @@ describe("release response handler", () => {
     translatedResponse : {resourceType: "Bundle"}
   }
 
-  test("handleResponse returns 400 response if spine response is a rejection", () => {
+  test("handleResponse returns 400 response if spine response is a rejection", async () => {
     const expectedSendMessagePayload = createRejection(
       "PORX_IN070101UK31",
       createAcknowledgementDetail("RejectionCode", "Rejection Display Name")
     )
     const spineResponse = writeXmlStringPretty({PORX_IN070101UK31: expectedSendMessagePayload})
-    const result = releaseResponseHandler.handleResponse(spineResponse, logger)
+    const result = await releaseResponseHandler.handleResponse(spineResponse, logger)
     expect(result).toMatchObject({
       statusCode: 400,
       fhirResponse: {
@@ -318,14 +318,14 @@ describe("release response handler", () => {
     })
   })
 
-  test("handleResponse returns 400 response if spine response is an error", () => {
+  test("handleResponse returns 400 response if spine response is an error", async () => {
     const expectedSendMessagePayload = createError(
       "PORX_IN070101UK31",
       mockReleaseResponseRoot,
       createSendMessagePayloadReason("ErrorCode", "Error Display Name", "ErrorCodeSystem")
     )
     const spineResponse = writeXmlStringPretty({PORX_IN070101UK31: expectedSendMessagePayload})
-    const result = releaseResponseHandler.handleResponse(spineResponse, logger)
+    const result = await releaseResponseHandler.handleResponse(spineResponse, logger)
     expect(result).toMatchObject({
       statusCode: 400,
       fhirResponse: {
@@ -335,7 +335,7 @@ describe("release response handler", () => {
     })
   })
 
-  test("handleResponse returns 200 response if spine response is a success", () => {
+  test("handleResponse returns 200 response if spine response is a success", async () => {
     const expectedSendMessagePayload = createSuccess(
       "PORX_IN070101UK31",
       mockReleaseResponseRoot
@@ -343,7 +343,7 @@ describe("release response handler", () => {
 
     const spineResponse = writeXmlStringPretty({PORX_IN070101UK31: expectedSendMessagePayload})
     mockTranslator.mockReturnValueOnce(mockTranslatorResponse)
-    const result = releaseResponseHandler.handleResponse(spineResponse, logger)
+    const result = await releaseResponseHandler.handleResponse(spineResponse, logger)
     expect(result).toEqual({
       statusCode: 200,
       fhirResponse: {resourceType: "Bundle"}
@@ -355,13 +355,13 @@ describe("release response handler", () => {
 describe("release rejection handler", () => {
   const releaseRejectionHandler = new ReleaseRejectionHandler("PORX_IN110101UK30")
 
-  test("handleResponse includes organization details on 0004", () => {
+  test("handleResponse includes organization details on 0004", async () => {
     const expectedSendMessagePayload = createError(
       "PORX_IN110101UK30",
       createReleaseRejectSubject(new hl7V3.PrescriptionReleaseRejectionReason("0004"))
     )
     const spineResponse = writeXmlStringPretty({PORX_IN110101UK30: expectedSendMessagePayload})
-    const result = releaseRejectionHandler.handleResponse(spineResponse, logger)
+    const result = await releaseRejectionHandler.handleResponse(spineResponse, logger)
 
     const outcomeIssue = createRejectionOperationOutcomeIssue(
       fhir.IssueCodes.BUSINESS_RULE,
@@ -399,13 +399,13 @@ describe("release rejection handler", () => {
     })
   })
 
-  test("handleResponse doesnt populate diagnostic info on other reason codes", () => {
+  test("handleResponse doesnt populate diagnostic info on other reason codes", async () => {
     const expectedSendMessagePayload = createError(
       "PORX_IN110101UK30",
       createReleaseRejectSubject(new hl7V3.PrescriptionReleaseRejectionReason("other reason code"))
     )
     const spineResponse = writeXmlStringPretty({PORX_IN110101UK30: expectedSendMessagePayload})
-    const result = releaseRejectionHandler.handleResponse(spineResponse, logger)
+    const result = await releaseRejectionHandler.handleResponse(spineResponse, logger)
     const operationOutcome = result.fhirResponse as fhir.OperationOutcome
     expect(operationOutcome.issue[0].diagnostics).toBeUndefined()
   })

--- a/packages/coordinator/tests/services/verification/certificate-revocation.spec.ts
+++ b/packages/coordinator/tests/services/verification/certificate-revocation.spec.ts
@@ -363,6 +363,8 @@ describe("Certificate verification edge cases", () => {
 
       const logPattern = "Cannot retrieve CRL distribution point from certificate"
       expect(loggerError).toHaveBeenCalledWith(expect.stringContaining(logPattern))
+
+      spy.mockRestore()
     })
 
     test.each([
@@ -378,6 +380,8 @@ describe("Certificate verification edge cases", () => {
 
       const detailsErrorPattern = `Unable to fetch CRL from ${url}`
       expect(loggerError).toHaveBeenCalledWith(expect.stringContaining(detailsErrorPattern))
+
+      certTextSpy.mockRestore()
     })
   })
 })

--- a/packages/coordinator/tests/services/verification/signature-verification.spec.ts
+++ b/packages/coordinator/tests/services/verification/signature-verification.spec.ts
@@ -224,18 +224,18 @@ describe("verifySignatureDigestMatchesPrescription...", () => {
     expect(result).toEqual(false)
   })
 
-  test("returns Signature doesn't match prescription", () => {
-    const result = verifyPrescriptionSignature(nonMatchingSignature, logger)
+  test("returns Signature doesn't match prescription", async () => {
+    const result = await verifyPrescriptionSignature(nonMatchingSignature, logger)
     expect(result).toContain("Signature doesn't match prescription")
   })
 
-  test("returns Signature is invalid", () => {
-    const result = verifyPrescriptionSignature(nonMatchingSignature, logger)
+  test("returns Signature is invalid", async () => {
+    const result = await verifyPrescriptionSignature(nonMatchingSignature, logger)
     expect(result).toContain("Signature is invalid")
   })
 
-  test("returns Signature match prescription", () => {
-    const result = verifyPrescriptionSignature(validSignature, logger)
+  test("returns Signature match prescription", async () => {
+    const result = await verifyPrescriptionSignature(validSignature, logger)
     expect(result).not.toContain("Signature doesn't match prescription")
     expect(result).not.toContain("Signature is invalid")
   })
@@ -245,13 +245,13 @@ describe("verifyPrescriptionSignatureValid...", () => {
   const validSignature = TestResources.parentPrescriptions.validSignature.ParentPrescription
   const invalidSignature = TestResources.parentPrescriptions.invalidSignature.ParentPrescription
 
-  test("Prescription with valid Signature that matches prescription returns true", () => {
-    const result = verifyPrescriptionSignatureValid(validSignature)
+  test("Prescription with valid Signature that matches prescription returns true", async () => {
+    const result = await verifyPrescriptionSignatureValid(validSignature)
     expect(result).toEqual(true)
   })
 
-  test("Prescription with invalid Signature that doesn't matches prescription returns false", () => {
-    const result = verifyPrescriptionSignatureValid(invalidSignature)
+  test("Prescription with invalid Signature that doesn't matches prescription returns false", async () => {
+    const result = await verifyPrescriptionSignatureValid(invalidSignature)
     expect(result).toEqual(false)
   })
 })
@@ -307,15 +307,15 @@ describe("verifyPrescriptionSignature", () => {
   const parentPrescription = TestResources.parentPrescriptions.validSignature.ParentPrescription
   const certExpiredErrorMessage = "Certificate expired when signed"
 
-  test("should return error message when verifyCertificate has errors", () => {
+  test("should return error message when verifyCertificate has errors", async () => {
     setSignatureTimeStamp(parentPrescription, "20210707120522")
-    const result = verifyPrescriptionSignature(parentPrescription, logger)
+    const result = await verifyPrescriptionSignature(parentPrescription, logger)
     const certificateHasExpired = result.includes(certExpiredErrorMessage)
     expect(certificateHasExpired).toBeTruthy()
   })
-  test("should not return error message when cert has not expired", () => {
+  test("should not return error message when cert has not expired", async () => {
     setSignatureTimeStamp(parentPrescription, "20210824120522")
-    const result = verifyPrescriptionSignature(parentPrescription, logger)
+    const result = await verifyPrescriptionSignature(parentPrescription, logger)
     const certificateHasExpired = result.includes(certExpiredErrorMessage)
     expect(certificateHasExpired).toBeFalsy()
   })

--- a/packages/coordinator/tests/services/verification/signature-verification.spec.ts
+++ b/packages/coordinator/tests/services/verification/signature-verification.spec.ts
@@ -73,13 +73,13 @@ describe("Verification of cert and signature", () => {
       expect(result).toEqual(false)
     })
 
-    test("returns Signature doesn't match prescription", () => {
-      const result = verifyPrescriptionSignature(nonMatchingSignature, logger)
+    test("returns Signature doesn't match prescription", async () => {
+      const result = await verifyPrescriptionSignature(nonMatchingSignature, logger)
       expect(result).toContain("Signature doesn't match prescription")
     })
 
-    test("returns Signature is invalid", () => {
-      const result = verifyPrescriptionSignature(nonMatchingSignature, logger)
+    test("returns Signature is invalid", async () => {
+      const result = await verifyPrescriptionSignature(nonMatchingSignature, logger)
       expect(result).toContain("Signature is invalid")
     })
     test("returns Signature match prescription", () => {
@@ -184,15 +184,15 @@ describe("Verification of cert and signature", () => {
     const parentPrescription = TestResources.parentPrescriptions.validSignature.ParentPrescription
     const certExpiredErrorMessage = "Certificate expired when signed"
 
-    test("should return error message when verifyCertificate has errors", () => {
+    test("should return error message when verifyCertificate has errors", async () => {
       setSignatureTimeStamp(parentPrescription, "20210707120522")
-      const result = verifyPrescriptionSignature(parentPrescription, logger)
+      const result = await verifyPrescriptionSignature(parentPrescription, logger)
       const certificateHasExpired = result.includes(certExpiredErrorMessage)
       expect(certificateHasExpired).toBeTruthy()
     })
-    test("should not return error message when cert has not expired", () => {
+    test("should not return error message when cert has not expired", async () => {
       setSignatureTimeStamp(parentPrescription, "20210824120522")
-      const result = verifyPrescriptionSignature(parentPrescription, logger)
+      const result = await verifyPrescriptionSignature(parentPrescription, logger)
       const certificateHasExpired = result.includes(certExpiredErrorMessage)
       expect(certificateHasExpired).toBeFalsy()
     })
@@ -208,52 +208,6 @@ describe("Verification of cert and signature", () => {
       .value = timeStamp
   }
 
-})
-
-describe("verifySignatureDigestMatchesPrescription...", () => {
-  const validSignature = TestResources.parentPrescriptions.validSignature.ParentPrescription
-  const nonMatchingSignature = TestResources.parentPrescriptions.nonMatchingSignature.ParentPrescription
-
-  test("Prescription with digest that matches prescription returns true", () => {
-    const result = verifySignatureDigestMatchesPrescription(validSignature)
-    expect(result).toEqual(true)
-  })
-
-  test("Prescription with digest that doesn't matches prescription returns false", () => {
-    const result = verifySignatureDigestMatchesPrescription(nonMatchingSignature)
-    expect(result).toEqual(false)
-  })
-
-  test("returns Signature doesn't match prescription", async () => {
-    const result = await verifyPrescriptionSignature(nonMatchingSignature, logger)
-    expect(result).toContain("Signature doesn't match prescription")
-  })
-
-  test("returns Signature is invalid", async () => {
-    const result = await verifyPrescriptionSignature(nonMatchingSignature, logger)
-    expect(result).toContain("Signature is invalid")
-  })
-
-  test("returns Signature match prescription", async () => {
-    const result = await verifyPrescriptionSignature(validSignature, logger)
-    expect(result).not.toContain("Signature doesn't match prescription")
-    expect(result).not.toContain("Signature is invalid")
-  })
-})
-
-describe("verifyPrescriptionSignatureValid...", () => {
-  const validSignature = TestResources.parentPrescriptions.validSignature.ParentPrescription
-  const invalidSignature = TestResources.parentPrescriptions.invalidSignature.ParentPrescription
-
-  test("Prescription with valid Signature that matches prescription returns true", async () => {
-    const result = await verifyPrescriptionSignatureValid(validSignature)
-    expect(result).toEqual(true)
-  })
-
-  test("Prescription with invalid Signature that doesn't matches prescription returns false", async () => {
-    const result = await verifyPrescriptionSignatureValid(invalidSignature)
-    expect(result).toEqual(false)
-  })
 })
 
 describe("extractSignatureDateTime", () => {
@@ -279,43 +233,6 @@ describe("verifyCertificate", () => {
   test("should not return error message when cert has not expired", () => {
     setSignatureTimeStamp(parentPrescription, "20210824120522")
     const result = verifyCertificate(parentPrescription)
-    const certificateHasExpired = result.includes(certExpiredErrorMessage)
-    expect(certificateHasExpired).toBeFalsy()
-  })
-})
-
-describe("verifyCertificateValidWhenSigned ", () => {
-  const parentPrescription = TestResources.parentPrescriptions.validSignature.ParentPrescription
-  test("should return false when signature date is before cert start date", () => {
-    setSignatureTimeStamp(parentPrescription, "20210707120522")
-    const result = verifyCertificateValidWhenSigned(parentPrescription)
-    expect(result).toBeFalsy()
-  })
-  test("should return false when signature date is after cert end date", () => {
-    setSignatureTimeStamp(parentPrescription, "202307120522")
-    const result = verifyCertificateValidWhenSigned(parentPrescription)
-    expect(result).toBeFalsy()
-  })
-  test("should return true when signature date is after cert start date and before cert end date", () => {
-    setSignatureTimeStamp(parentPrescription, "20210824120522")
-    const result = verifyCertificateValidWhenSigned(parentPrescription)
-    expect(result).toBeTruthy()
-  })
-})
-
-describe("verifyPrescriptionSignature", () => {
-  const parentPrescription = TestResources.parentPrescriptions.validSignature.ParentPrescription
-  const certExpiredErrorMessage = "Certificate expired when signed"
-
-  test("should return error message when verifyCertificate has errors", async () => {
-    setSignatureTimeStamp(parentPrescription, "20210707120522")
-    const result = await verifyPrescriptionSignature(parentPrescription, logger)
-    const certificateHasExpired = result.includes(certExpiredErrorMessage)
-    expect(certificateHasExpired).toBeTruthy()
-  })
-  test("should not return error message when cert has not expired", async () => {
-    setSignatureTimeStamp(parentPrescription, "20210824120522")
-    const result = await verifyPrescriptionSignature(parentPrescription, logger)
     const certificateHasExpired = result.includes(certExpiredErrorMessage)
     expect(certificateHasExpired).toBeFalsy()
   })


### PR DESCRIPTION
When we verify the certificate on a signature, we need to fetch the partitioned CRL, so functions needed to be converted to async.

- Made src and test functions async
- Made number of jest workers fixed to fix random test failures