### PR TITLE
AEA-3556 use support create release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,12 @@ updates:
     rebase-strategy: "disabled"
     schedule:
       interval: "daily"
+
+  ###################################
+  # Poetry  #########################
+  ###################################
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,13 +46,14 @@ jobs:
       - name: Create release (master only)
         id: create-release
         if: github.ref == 'refs/heads/master'
-        uses: actions/create-release@v1
+        # using commit hash for version v1.13.0
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.SPEC_VERSION }}
-          release_name: ${{ env.SPEC_VERSION }}
+          tag: ${{ env.SPEC_VERSION }}
+          commit: ${{  github.sha }}
           body: |
             ## Commit message
             ${{ github.event.head_commit.message }}


### PR DESCRIPTION
## Summary

**Remove items from this list if they are not relevant. Remove this line once this has been done**

- Routine Change

### Details

- Use https://github.com/ncipollo/release-action to create a release as actions/create-release@v1 is not supported
- Use correct config for dependabot python

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
