### PR TITLE
AEA-3524 OAS Improvement - Append indication/reason to dosage.text

### DIFF
--- a/packages/specification/schemas/components/MedicationRequest/MedicationRequest.yaml
+++ b/packages/specification/schemas/components/MedicationRequest/MedicationRequest.yaml
@@ -13,7 +13,10 @@ required:
   - dosageInstruction
   - dispenseRequest
   - substitution
-description: A MedicationRequest object is required. An EPS prescription must contain at least one and up to four MedicationRequest objects. This is equivalent to an item on a prescription.
+description: |
+  A MedicationRequest object is required. An EPS prescription must contain at least one and up to four MedicationRequest objects. This is equivalent to an item on a prescription.
+  Any fields mentioned in the Simplifer Spec but not in this schema are permitted, but may not be preserved or acted on by the API. 
+  Reason for medication dispense should be appended to dosageInstruction.text, as reasonCode is not made available to dispensers.
 properties:
   resourceType:
     type: string


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Adds a note to `MedicationRequest` that fields in the Simplifier spec that are not present in the OAS may not be preserved, with a specific note around `reasonCode`

## Reviews Required

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
