### PR TITLE
AEA-3666: OAS Dispense - Withdraw page Try button returns 400 Bad Request

### DIFF
--- a/examples/spec/dispensing/withdraw/acute-primary-example-req.json
+++ b/examples/spec/dispensing/withdraw/acute-primary-example-req.json
@@ -52,7 +52,11 @@
         {
           "city": "West Yorkshire",
           "use": "work",
-          "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+          "line": [
+            "17 Austhorpe Road",
+            "Crossgates",
+            "Leeds"
+          ],
           "postalCode": "LS15 8BA"
         }
       ],
@@ -99,7 +103,7 @@
     "system": "https://fhir.nhs.uk/Id/prescription-order-number",
     "value": "24F5DA-A83008-7EFE6Z"
   },
-  "status": "cancelled",
+  "status": "in-progress",
   "statusReason": {
     "coding": [
       {

--- a/examples/spec/dispensing/withdraw/eRD-primary-example-req.json
+++ b/examples/spec/dispensing/withdraw/eRD-primary-example-req.json
@@ -129,7 +129,7 @@
     "system": "https://fhir.nhs.uk/Id/prescription-order-number",
     "value": "24F5DA-A83008-7EFE6Z"
   },
-  "status": "cancelled",
+  "status": "in-progress",
   "statusReason": {
     "coding": [
       {

--- a/examples/spec/dispensing/withdraw/repeat-primary-example-req.json
+++ b/examples/spec/dispensing/withdraw/repeat-primary-example-req.json
@@ -125,7 +125,7 @@
     "system": "https://fhir.nhs.uk/Id/prescription-order-number",
     "value": "24F5DA-A83008-7EFE6Z"
   },
-  "status": "cancelled",
+  "status": "in-progress",
   "statusReason": {
     "coding": [
       {


### PR DESCRIPTION
## Summary

**Remove items from this list if they are not relevant. Remove this line once this has been done**

- Routine Change

### Details
- Documentation change.
-  `status` field can only accept `in-progress` or `rejected` for _Withdraw - Despensing_ 
- Edits the value of `status` in the requests of _acute_, _repeat_ and _eRD_ within _Withdraw - Despensing_ from `cancelled` to `in-progress`.
- This change should result in *200* instead of *400*.

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
