### PR TITLE
AEA-3681 Remove prescription search tracking information from API catalogue

### DIFF
--- a/packages/specification/electronic-prescription-service-api.yaml
+++ b/packages/specification/electronic-prescription-service-api.yaml
@@ -206,8 +206,6 @@ x-spec-publication:
           path: /FHIR/R4/Task#return
         - method: POST
           path: /FHIR/R4/Task#withdraw
-        - method: GET
-          path: /FHIR/R4/Task
 
 servers:
   - url: "https://sandbox.api.service.nhs.uk/electronic-prescriptions"
@@ -217,7 +215,6 @@ servers:
 tags:
   - name: prescribing
   - name: dispensing
-  - name: tracking
 paths:
   /FHIR/R4/$prepare:
     post:
@@ -913,22 +910,6 @@ paths:
                     An error response.
                   value:
                     $ref: examples/spec/errors/example-a-validation-error-missing-field/Response-FhirError.json
-  /FHIR/R4/Task:
-    get:
-      operationId: get-task
-      summary: Search for a patient's prescription
-      description: |
-        ## Overview
-        This capability is under active development, and is only for use when the end user is a healthcare worker, not a patient.  
-        
-        If you're interested in learning more, contact epsonboarding@nhs.net.
-      tags:
-        - tracking
-      responses:
-        '200':
-          description: Successful retrieval.
-        '400':
-          description: Invalid request.
 
 components:
   parameters:


### PR DESCRIPTION
## Summary
🎫 Jira Reference: [AEA-3681](https://nhsd-jira.digital.nhs.uk/browse/AEA-3681)
The prescription search tracking information is removed from the API catalogue.

- Routine Change
- :exclamation: Breaking Change
- :warning: Potential issues that might be caused by this change

### Details

The prescription search tracking information needs to be removed from the API catalogue here: [https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#get-/FHIR/R4/Task, ](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#get-/FHIR/R4/Task)in light of the development of the new Clinical Prescriptions Tracker.

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [x] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
