### PR TITLE
AEA- 3691 Update Reason Codes in the schema for 'Not Dispensed' in the Dispense Notification

### DIFF
--- a/packages/specification/schemas/components/MedicationDispense/MedicationDispense.yaml
+++ b/packages/specification/schemas/components/MedicationDispense/MedicationDispense.yaml
@@ -65,11 +65,22 @@ properties:
             code:
               type: string
               description: Status reason code representing why the medication was not dispensed.
-              example: "0003"
+              enum: ["0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011"]
             display:
               type: string
               description: Human readable representation of the code.
-              example: Owings note issued to patient
+              enum:
+              - Not required as instructed by the patient
+              - Clinically unsuitable
+              - Owings note issued to patient
+              - Prescription cancellation
+              - Prescription cancellation due to death
+              - Illegal NHS prescription
+              - Prescribed out of scope item
+              - Item or prescription expired
+              - Not allowed on FP10
+              - Patient did not collect medication
+              - Patient purchased medication over the counter
   medicationCodeableConcept:
     type: object
     description: |


### PR DESCRIPTION
## Summary

Ticket https://nhsd-jira.digital.nhs.uk/browse/AEA-3691

- Routine Change

### Details

In our Dispensing schema we mention in the dispense notification section about 'Not Dispensed' prescriptions. This though doesn't give suppliers all the information required to help with onboarding to our API. 

Within the `statusReasonCodeableConcept` field in the `MedicationDispense` edit the `code` and `display` fields to contain their respective enums:

Code	Display
0001	Not required as instructed by the patient	
0002	Clinically unsuitable	
0003	Owings note issued to patient	
0004	Prescription cancellation	
0005	Prescription cancellation due to death	
0006	Illegal NHS prescription	
0007	Prescribed out of scope item	
0008	Item or prescription expired	
0009	Not allowed on FP10	
0010	Patient did not collect medication	
0011	Patient purchased medication over the counter	

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
