### PR TITLE
AEA-3665 OAS Dispense - Notification page Try button returns 400 Bad Request 

### DIFF
--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-01-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-01-req.json
@@ -848,16 +848,7 @@
             "value": "6318367c-c343-4a65-95de-69f712edfc39"
           }
         ],
-        "status": "on-hold",
-        "statusReasonCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
-              "code": "0003",
-              "display": "Owings note issued to patient"
-            }
-          ]
-        },
+        "status": "completed",
         "medicationCodeableConcept": {
           "coding": [
             {
@@ -892,7 +883,7 @@
             {
               "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
               "code": "0004",
-              "display": "Item not dispensed owing"
+              "display": "Item fully dispensed"
             }
           ]
         },
@@ -912,7 +903,36 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+        "daysSupply": {
+          "value": 10,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -970,31 +990,14 @@
                 }
               },
               {
-                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
-                "extension": [
-                  {
-                    "url": "status",
-                    "valueCoding": {
-                      "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-history",
-                      "code": "R-0001",
-                      "display": "Prescription/item was cancelled"
-                    }
-                  },
-                  {
-                    "url": "statusDate",
-                    "valueDateTime": "2022-10-21T13:48:00+00:00"
-                  }
-                ]
-              },
-              {
                 "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
                 "extension": [
                   {
                     "url": "dispenseStatus",
                     "valueCoding": {
                       "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
-                      "code": "0005",
-                      "display": "Item cancelled"
+                      "code": "0008",
+                      "display": "Item with dispenser"
                     }
                   }
                 ]
@@ -1006,16 +1009,7 @@
                 "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
               }
             ],
-            "status": "cancelled",
-            "statusReason": {
-              "coding": [
-                {
-                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-reason",
-                  "code": "0002",
-                  "display": "Clinical contra-indication"
-                }
-              ]
-            },
+            "status": "completed",
             "intent": "order",
             "category": [
               {
@@ -1147,16 +1141,7 @@
             "value": "9a0aa5fd-8865-42f5-ad67-6c83d0944ee0"
           }
         ],
-        "status": "cancelled",
-        "statusReasonCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
-              "code": "0004",
-              "display": "Prescription cancellation"
-            }
-          ]
-        },
+        "status": "completed",
         "medicationCodeableConcept": {
           "coding": [
             {
@@ -1191,7 +1176,7 @@
             {
               "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
               "code": "0005",
-              "display": "Item cancelled"
+              "display": "Item fully dispensed"
             }
           ]
         },
@@ -1211,7 +1196,36 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+        "daysSupply": {
+          "value": 10,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-02-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-02-req.json
@@ -848,16 +848,7 @@
             "value": "496f4a02-a845-4f19-934e-ae1a7e12a193"
           }
         ],
-        "status": "on-hold",
-        "statusReasonCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
-              "code": "0003",
-              "display": "Owings note issued to patient"
-            }
-          ]
-        },
+        "status": "completed",
         "medicationCodeableConcept": {
           "coding": [
             {
@@ -919,8 +910,8 @@
           "system": "http://unitsofmeasure.org",
           "code": "d"
         },
-        "whenPrepared": "2022-11-28T11:45:00+00:00",
-        "whenHandedOver": "2022-11-28T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
         "dosageInstruction": [
           {
             "text": "15 tablets. One tablet to be taken three times a day",
@@ -1004,26 +995,9 @@
                   {
                     "url": "status",
                     "valueCoding": {
-                      "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-history",
-                      "code": "R-0001",
-                      "display": "Prescription/item was cancelled"
-                    }
-                  },
-                  {
-                    "url": "statusDate",
-                    "valueDateTime": "2022-10-21T13:48:00+00:00"
-                  }
-                ]
-              },
-              {
-                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
-                "extension": [
-                  {
-                    "url": "dispenseStatus",
-                    "valueCoding": {
                       "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
-                      "code": "0005",
-                      "display": "Item cancelled"
+                      "code": "0008",
+                      "display": "Item with dispenser"
                     }
                   }
                 ]
@@ -1035,16 +1009,7 @@
                 "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
               }
             ],
-            "status": "cancelled",
-            "statusReason": {
-              "coding": [
-                {
-                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-reason",
-                  "code": "0002",
-                  "display": "Clinical contra-indication"
-                }
-              ]
-            },
+            "status": "active",
             "intent": "order",
             "category": [
               {
@@ -1176,16 +1141,7 @@
             "value": "213a4581-99c8-4ddf-a43a-3de14f8c4372"
           }
         ],
-        "status": "cancelled",
-        "statusReasonCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
-              "code": "0004",
-              "display": "Prescription cancellation"
-            }
-          ]
-        },
+        "status": "completed",
         "medicationCodeableConcept": {
           "coding": [
             {
@@ -1220,7 +1176,7 @@
             {
               "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
               "code": "0005",
-              "display": "Item cancelled"
+              "display": "Item fully dispensed"
             }
           ]
         },
@@ -1240,7 +1196,36 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+        "daysSupply": {
+          "value": 5,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "15 tablets. One tablet to be taken three times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 3,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-03-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-03-req.json
@@ -910,8 +910,8 @@
           "system": "http://unitsofmeasure.org",
           "code": "d"
         },
-        "whenPrepared": "2022-11-29T11:45:00+00:00",
-        "whenHandedOver": "2022-11-29T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
         "dosageInstruction": [
           {
             "text": "15 tablets. One tablet to be taken three times a day",
@@ -990,31 +990,14 @@
                 }
               },
               {
-                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
-                "extension": [
-                  {
-                    "url": "status",
-                    "valueCoding": {
-                      "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-history",
-                      "code": "R-0001",
-                      "display": "Prescription/item was cancelled"
-                    }
-                  },
-                  {
-                    "url": "statusDate",
-                    "valueDateTime": "2022-10-21T13:48:00+00:00"
-                  }
-                ]
-              },
-              {
                 "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
                 "extension": [
                   {
                     "url": "dispenseStatus",
                     "valueCoding": {
                       "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
-                      "code": "0005",
-                      "display": "Item cancelled"
+                      "code": "0008",
+                      "display": "Item with dispenser"
                     }
                   }
                 ]
@@ -1026,16 +1009,8 @@
                 "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
               }
             ],
-            "status": "cancelled",
-            "statusReason": {
-              "coding": [
-                {
-                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-reason",
-                  "code": "0002",
-                  "display": "Clinical contra-indication"
-                }
-              ]
-            },
+            "status": "completed",
+            
             "intent": "order",
             "category": [
               {
@@ -1167,16 +1142,7 @@
             "value": "213a4581-99c8-4ddf-a43a-3de14f8c4372"
           }
         ],
-        "status": "cancelled",
-        "statusReasonCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
-              "code": "0004",
-              "display": "Prescription cancellation"
-            }
-          ]
-        },
+        "status": "completed",
         "medicationCodeableConcept": {
           "coding": [
             {
@@ -1211,7 +1177,7 @@
             {
               "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
               "code": "0005",
-              "display": "Item cancelled"
+              "display": "Item fully dispensed"
             }
           ]
         },
@@ -1231,7 +1197,36 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+        "daysSupply": {
+          "value": 5,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "15 tablets. One tablet to be taken three times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 3,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-04-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-04-req.json
@@ -919,8 +919,8 @@
           "system": "http://unitsofmeasure.org",
           "code": "d"
         },
-        "whenPrepared": "2022-11-29T11:45:00+00:00",
-        "whenHandedOver": "2022-11-29T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
         "dosageInstruction": [
           {
             "text": "15 tablets. One tablet to be taken three times a day",
@@ -999,31 +999,14 @@
                 }
               },
               {
-                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
-                "extension": [
-                  {
-                    "url": "status",
-                    "valueCoding": {
-                      "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-history",
-                      "code": "R-0001",
-                      "display": "Prescription/item was cancelled"
-                    }
-                  },
-                  {
-                    "url": "statusDate",
-                    "valueDateTime": "2022-10-21T13:48:00+00:00"
-                  }
-                ]
-              },
-              {
                 "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
                 "extension": [
                   {
                     "url": "dispenseStatus",
                     "valueCoding": {
                       "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
-                      "code": "0005",
-                      "display": "Item cancelled"
+                      "code": "0008",
+                      "display": "Item with dispenser"
                     }
                   }
                 ]
@@ -1035,16 +1018,7 @@
                 "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
               }
             ],
-            "status": "cancelled",
-            "statusReason": {
-              "coding": [
-                {
-                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-reason",
-                  "code": "0002",
-                  "display": "Clinical contra-indication"
-                }
-              ]
-            },
+            "status": "active",
             "intent": "order",
             "category": [
               {
@@ -1176,16 +1150,7 @@
             "value": "213a4581-99c8-4ddf-a43a-3de14f8c4372"
           }
         ],
-        "status": "cancelled",
-        "statusReasonCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
-              "code": "0004",
-              "display": "Prescription cancellation"
-            }
-          ]
-        },
+        "status": "completed",
         "medicationCodeableConcept": {
           "coding": [
             {
@@ -1220,7 +1185,7 @@
             {
               "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
               "code": "0005",
-              "display": "Item cancelled"
+              "display": "Item fully dispensed"
             }
           ]
         },
@@ -1240,7 +1205,36 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+        "daysSupply": {
+          "value": 5,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "15 tablets. One tablet to be taken three times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 3,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -1271,11 +1265,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": [
-              "17 Austhorpe Road",
-              "Crossgates",
-              "Leeds"
-            ],
+            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/examples/spec/dispensing/dispense-notification/eRD-primary-example-req.json
+++ b/examples/spec/dispensing/dispense-notification/eRD-primary-example-req.json
@@ -1,30 +1,1482 @@
 {
-  "resourceType": "Parameters",
-  "id": "528c59b4-1ec4-4434-8812-d08d78e22000",
-  "parameter": [
+  "resourceType": "Bundle",
+  "id": "b240434e-cb85-40bb-899c-1c61410c93a7",
+  "timestamp": "2022-11-27T11:45:00+00:00",
+  "identifier": {
+    "system": "https://tools.ietf.org/html/rfc4122",
+    "value": "b240434e-cb85-40bb-899c-1c61410c93a7"
+  },
+  "type": "message",
+  "entry": [
     {
-      "name": "owner",
+      "fullUrl": "urn:uuid:e9a71955-53ba-b15a-d4b6-bea99d5017b3",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "eventCoding": {
+          "system": "https://fhir.nhs.uk/CodeSystem/message-event",
+          "code": "dispense-notification",
+          "display": "Dispense Notification"
+        },
+        "sender": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "VNE51"
+          },
+          "display": "The Simple Pharmacy"
+        },
+        "source": {
+          "endpoint": "https://directory.spineservices.nhs.uk/STU3/Organization/VNE51"
+        },
+        "reason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/message-reason-prescription",
+              "code": "notification",
+              "display": "Notification"
+            }
+          ]
+        },
+        "response": {
+          "identifier": "a5d77265-8ba5-4c74-b8ce-ea0dbaafbdb8",
+          "code": "ok"
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:4509b70d-d8b8-ea03-1105-64557cb54a29"
+          },
+          {
+            "reference": "urn:uuid:06167339-9337-d030-0366-514a6a46da17"
+          },
+          {
+            "reference": "urn:uuid:6318367c-c343-4a65-95de-69f712edfc39"
+          },
+          {
+            "reference": "urn:uuid:9a0aa5fd-8865-42f5-ad67-6c83d0944ee0"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4509b70d-d8b8-ea03-1105-64557cb54a29",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "contained": [
+          {
+            "resourceType": "PractitionerRole",
+            "id": "performer",
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "741555508105"
+              }
+            ],
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/CodeSystem/NHSDigital-SDS-JobRoleCode",
+                    "code": "S0030:G0100:R0620"
+                  }
+                ]
+              }
+            ],
+            "practitioner": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                "value": "7654321"
+              },
+              "display": "Mr Peter Potion"
+            },
+            "organization": {
+              "reference": "urn:uuid:2bf9f37c-d88b-4f86-ad5f-373c1416e04b"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "use": "work",
+                "value": "0532567890"
+              }
+            ]
+          },
+          {
+            "resourceType": "MedicationRequest",
+            "id": "m1",
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType",
+                "valueCoding": {
+                  "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+                  "code": "0101",
+                  "display": "Primary Care Prescriber - Medical Prescriber"
+                }
+              },
+              {
+                "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation",
+                "extension": [
+                  {
+                    "url": "authorisationExpiryDate",
+                    "valueDateTime": "2023-04-07"
+                  }
+                ]
+              },
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
+                "extension": [
+                  {
+                    "url": "dispenseStatus",
+                    "valueCoding": {
+                      "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+                      "code": "0008",
+                      "display": "Item with dispenser"
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                "value": "a54219b8-f741-4c47-b662-e4f8dfa49ab6"
+              }
+            ],
+            "status": "active",
+            "intent": "reflex-order",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                    "code": "community",
+                    "display": "Community"
+                  }
+                ]
+              }
+            ],
+            "medicationCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "39732311000001104",
+                  "display": "Amoxicillin 250mg capsules"
+                }
+              ]
+            },
+            "subject": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/nhs-number",
+                "value": "9449304130"
+              },
+              "display": "Ms Marisa Stacey Twitchett"
+            },
+            "authoredOn": "2022-10-21T13:47:00+00:00",
+            "requester": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "200102238987"
+              }
+            },
+            "basedOn": [
+              {
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                    "extension": [
+                      {
+                        "url": "numberOfRepeatsAllowed",
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
+                      }
+                    ]
+                  }
+                ],
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                  "value": "299c610b-f4f1-4eac-a7d7-4fb6b0556e11"
+                }
+              }
+            ],
+            "groupIdentifier": {
+              "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+              "value": "24F5DA-A83008-7EFE6Z",
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId",
+                  "valueIdentifier": {
+                    "system": "https://fhir.nhs.uk/Id/prescription",
+                    "value": "20ba5fb5-cb58-462c-923e-22d180b09356"
+                  }
+                }
+              ]
+            },
+            "courseOfTherapyType": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-course-of-therapy",
+                  "code": "continuous-repeat-dispensing",
+                  "display": "Continuous long term (repeat dispensing)"
+                }
+              ]
+            },
+            "dosageInstruction": [
+              {
+                "text": "2 times a day for 10 days",
+                "timing": {
+                  "repeat": {
+                    "frequency": 2,
+                    "period": 1,
+                    "periodUnit": "d"
+                  }
+                },
+                "route": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "26643006",
+                      "display": "Oral"
+                    }
+                  ]
+                }
+              }
+            ],
+            "dispenseRequest": {
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType",
+                  "valueCoding": {
+                    "system": "https://fhir.nhs.uk/CodeSystem/dispensing-site-preference",
+                    "code": "P1"
+                  }
+                }
+              ],
+              "validityPeriod": {
+                "start": "2022-10-21"
+              },
+              "numberOfRepeatsAllowed": 0,
+              "quantity": {
+                "value": 20,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "428673006"
+              },
+              "expectedSupplyDuration": {
+                "value": 10,
+                "unit": "day",
+                "system": "http://unitsofmeasure.org",
+                "code": "d"
+              },
+              "performer": {
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                  "value": "VNE51"
+                }
+              }
+            },
+            "substitution": {
+              "allowedBoolean": false
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+              "code": "0003",
+              "display": "With Dispenser - Active"
+            }
+          },
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+            "extension": [
+              {
+                "url": "numberOfRepeatsAllowed",
+                "valueInteger": 5
+              },
+              {
+                "url": "numberOfRepeatsIssued",
+                "valueInteger": 2
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-dispense-item-number",
+            "value": "fd833d33-f128-4fa2-a807-1fc8a7db2658"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "39732311000001104",
+              "display": "Amoxicillin 250mg capsules"
+            }
+          ]
+        },
+        "subject": {
+          "type": "Patient",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9449304130"
+          },
+          "display": "Ms Marisa Stacey Twitchett"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "#performer"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "#m1"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+              "code": "0001",
+              "display": "Item fully dispensed"
+            }
+          ]
+        },
+        "quantity": {
+          "extension": [
+            {
+              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
+              "valueQuantity": {
+                "value": 20,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "732936001"
+              }
+            }
+          ],
+          "value": 20,
+          "unit": "tablet",
+          "system": "http://snomed.info/sct",
+          "code": "732936001"
+        },
+        "daysSupply": {
+          "value": 10,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06167339-9337-d030-0366-514a6a46da17",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "contained": [
+          {
+            "resourceType": "PractitionerRole",
+            "id": "performer",
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "741555508105"
+              }
+            ],
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/CodeSystem/NHSDigital-SDS-JobRoleCode",
+                    "code": "S0030:G0100:R0620"
+                  }
+                ]
+              }
+            ],
+            "practitioner": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                "value": "7654321"
+              },
+              "display": "Mr Peter Potion"
+            },
+            "organization": {
+              "reference": "urn:uuid:2bf9f37c-d88b-4f86-ad5f-373c1416e04b"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "use": "work",
+                "value": "0532567890"
+              }
+            ]
+          },
+          {
+            "resourceType": "MedicationRequest",
+            "id": "m2",
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType",
+                "valueCoding": {
+                  "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+                  "code": "0101",
+                  "display": "Primary Care Prescriber - Medical Prescriber"
+                }
+              },
+              {
+                "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation",
+                "extension": [
+                  {
+                    "url": "authorisationExpiryDate",
+                    "valueDateTime": "2023-04-07"
+                  }
+                ]
+              },
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
+                "extension": [
+                  {
+                    "url": "dispenseStatus",
+                    "valueCoding": {
+                      "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+                      "code": "0008",
+                      "display": "Item with dispenser"
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                "value": "6989b7bd-8db6-428c-a593-4022e3044c00"
+              }
+            ],
+            "status": "active",
+            "intent": "reflex-order",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                    "code": "community",
+                    "display": "Community"
+                  }
+                ]
+              }
+            ],
+            "medicationCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "322341003",
+                  "display": "Co-codamol 30mg/500mg tablets"
+                }
+              ]
+            },
+            "subject": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/nhs-number",
+                "value": "9449304130"
+              },
+              "display": "Ms Marisa Stacey Twitchett"
+            },
+            "authoredOn": "2022-10-21T13:47:00+00:00",
+            "requester": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "200102238987"
+              }
+            },
+            "basedOn": [
+              {
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                    "extension": [
+                      {
+                        "url": "numberOfRepeatsAllowed",
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
+                      }
+                    ]
+                  }
+                ],
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                  "value": "299c610b-f4f1-4eac-a7d7-4fb6b0556e11"
+                }
+              }
+            ],
+            "groupIdentifier": {
+              "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+              "value": "24F5DA-A83008-7EFE6Z",
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId",
+                  "valueIdentifier": {
+                    "system": "https://fhir.nhs.uk/Id/prescription",
+                    "value": "20ba5fb5-cb58-462c-923e-22d180b09356"
+                  }
+                }
+              ]
+            },
+            "courseOfTherapyType": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-course-of-therapy",
+                  "code": "continuous-repeat-dispensing",
+                  "display": "Continuous long term (repeat dispensing)"
+                }
+              ]
+            },
+            "dosageInstruction": [
+              {
+                "text": "2 times a day for 10 days",
+                "timing": {
+                  "repeat": {
+                    "frequency": 2,
+                    "period": 1,
+                    "periodUnit": "d"
+                  }
+                },
+                "route": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "26643006",
+                      "display": "Oral"
+                    }
+                  ]
+                }
+              }
+            ],
+            "dispenseRequest": {
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType",
+                  "valueCoding": {
+                    "system": "https://fhir.nhs.uk/CodeSystem/dispensing-site-preference",
+                    "code": "P1"
+                  }
+                }
+              ],
+              "validityPeriod": {
+                "start": "2022-10-21"
+              },
+			        "numberOfRepeatsAllowed": 0,
+              "quantity": {
+                "value": 20,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "428673006"
+              },
+              "expectedSupplyDuration": {
+                "value": 10,
+                "unit": "day",
+                "system": "http://unitsofmeasure.org",
+                "code": "d"
+              },
+              "performer": {
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                  "value": "VNE51"
+                }
+              }
+            },
+            "substitution": {
+              "allowedBoolean": false
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+              "code": "0003",
+              "display": "With Dispenser - Active"
+            }
+          },
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+            "extension": [
+              {
+                "url": "numberOfRepeatsAllowed",
+                "valueInteger": 5
+              },
+              {
+                "url": "numberOfRepeatsIssued",
+                "valueInteger": 2
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-dispense-item-number",
+            "value": "06167339-9337-d030-0366-514a6a46da17"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "322341003",
+              "display": "Co-codamol 30mg/500mg tablets"
+            }
+          ]
+        },
+        "subject": {
+          "type": "Patient",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9449304130"
+          },
+          "display": "Ms Marisa Stacey Twitchett"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "#performer"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "#m2"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+              "code": "0001",
+              "display": "Item fully dispensed"
+            }
+          ]
+        },
+        "quantity": {
+          "extension": [
+            {
+              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
+              "valueQuantity": {
+                "value": 20,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "732936001"
+              }
+            }
+          ],
+          "value": 20,
+          "unit": "tablet",
+          "system": "http://snomed.info/sct",
+          "code": "732936001"
+        },
+        "daysSupply": {
+          "value": 10,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6318367c-c343-4a65-95de-69f712edfc39",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "contained": [
+          {
+            "resourceType": "PractitionerRole",
+            "id": "performer",
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "741555508105"
+              }
+            ],
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/CodeSystem/NHSDigital-SDS-JobRoleCode",
+                    "code": "S0030:G0100:R0620"
+                  }
+                ]
+              }
+            ],
+            "practitioner": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                "value": "7654321"
+              },
+              "display": "Mr Peter Potion"
+            },
+            "organization": {
+              "reference": "urn:uuid:2bf9f37c-d88b-4f86-ad5f-373c1416e04b"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "use": "work",
+                "value": "0532567890"
+              }
+            ]
+          },
+          {
+            "resourceType": "MedicationRequest",
+            "id": "m3",
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType",
+                "valueCoding": {
+                  "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+                  "code": "0101",
+                  "display": "Primary Care Prescriber - Medical Prescriber"
+                }
+              },
+              {
+                "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation",
+                "extension": [
+                  {
+                    "url": "authorisationExpiryDate",
+                    "valueDateTime": "2023-04-07"
+                  }
+                ]
+              },
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
+                "extension": [
+                  {
+                    "url": "dispenseStatus",
+                    "valueCoding": {
+                      "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+                      "code": "0008",
+                      "display": "Item with dispenser"
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                "value": "2868554c-5565-4d31-b92a-c5b8dab8b90a"
+              }
+            ],
+            "status": "active",
+            "intent": "reflex-order",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                    "code": "community",
+                    "display": "Community"
+                  }
+                ]
+              }
+            ],
+            "medicationCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "321080004",
+                  "display": "Pseudoephedrine hydrochloride 60mg tablets"
+                }
+              ]
+            },
+            "subject": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/nhs-number",
+                "value": "9449304130"
+              },
+              "display": "Ms Marisa Stacey Twitchett"
+            },
+            "authoredOn": "2022-10-21T13:47:00+00:00",
+            "requester": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "200102238987"
+              }
+            },
+            "basedOn": [
+              {
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                    "extension": [
+                      {
+                        "url": "numberOfRepeatsAllowed",
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
+                      }
+                    ]
+                  }
+                ],
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                  "value": "299c610b-f4f1-4eac-a7d7-4fb6b0556e11"
+                }
+              }
+            ],
+            "groupIdentifier": {
+              "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+              "value": "24F5DA-A83008-7EFE6Z",
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId",
+                  "valueIdentifier": {
+                    "system": "https://fhir.nhs.uk/Id/prescription",
+                    "value": "20ba5fb5-cb58-462c-923e-22d180b09356"
+                  }
+                }
+              ]
+            },
+            "courseOfTherapyType": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-course-of-therapy",
+                  "code": "continuous-repeat-dispensing",
+                  "display": "Continuous long term (repeat dispensing)"
+                }
+              ]
+            },
+            "dosageInstruction": [
+              {
+                "text": "3 times a day for 10 days",
+                "timing": {
+                  "repeat": {
+                    "frequency": 3,
+                    "period": 1,
+                    "periodUnit": "d"
+                  }
+                },
+                "route": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "26643006",
+                      "display": "Oral"
+                    }
+                  ]
+                }
+              }
+            ],
+            "dispenseRequest": {
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType",
+                  "valueCoding": {
+                    "system": "https://fhir.nhs.uk/CodeSystem/dispensing-site-preference",
+                    "code": "P1"
+                  }
+                }
+              ],
+              "validityPeriod": {
+                "start": "2022-10-21"
+              },
+			        "numberOfRepeatsAllowed": 0,
+              "quantity": {
+                "value": 30,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "428673006"
+              },
+              "expectedSupplyDuration": {
+                "value": 10,
+                "unit": "day",
+                "system": "http://unitsofmeasure.org",
+                "code": "d"
+              },
+              "performer": {
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                  "value": "VNE51"
+                }
+              }
+            },
+            "substitution": {
+              "allowedBoolean": false
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+              "code": "0003",
+              "display": "With Dispenser - Active"
+            }
+          },
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+            "extension": [
+              {
+                "url": "numberOfRepeatsAllowed",
+                "valueInteger": 5
+              },
+              {
+                "url": "numberOfRepeatsIssued",
+                "valueInteger": 2
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-dispense-item-number",
+            "value": "6318367c-c343-4a65-95de-69f712edfc39"
+          }
+        ],
+        "status": "on-hold",
+        "statusReasonCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
+              "code": "0003",
+              "display": "Owings note issued to patient"
+            }
+          ]
+        },
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "321080004",
+              "display": "Pseudoephedrine hydrochloride 60mg tablets"
+            }
+          ]
+        },
+        "subject": {
+          "type": "Patient",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9449304130"
+          },
+          "display": "Ms Marisa Stacey Twitchett"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "#performer"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "#m3"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+              "code": "0004",
+              "display": "Item not dispensed owing"
+            }
+          ]
+        },
+        "quantity": {
+          "extension": [
+            {
+              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
+              "valueQuantity": {
+                "value": 0,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "732936001"
+              }
+            }
+          ],
+          "value": 0,
+          "unit": "tablet",
+          "system": "http://snomed.info/sct",
+          "code": "732936001"
+        },
+		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+		    "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9a0aa5fd-8865-42f5-ad67-6c83d0944ee0",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "contained": [
+          {
+            "resourceType": "PractitionerRole",
+            "id": "performer",
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "741555508105"
+              }
+            ],
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/CodeSystem/NHSDigital-SDS-JobRoleCode",
+                    "code": "S0030:G0100:R0620"
+                  }
+                ]
+              }
+            ],
+            "practitioner": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                "value": "7654321"
+              },
+              "display": "Mr Peter Potion"
+            },
+            "organization": {
+              "reference": "urn:uuid:2bf9f37c-d88b-4f86-ad5f-373c1416e04b"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "use": "work",
+                "value": "0532567890"
+              }
+            ]
+          },
+          {
+            "resourceType": "MedicationRequest",
+            "id": "m4",
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType",
+                "valueCoding": {
+                  "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+                  "code": "0101",
+                  "display": "Primary Care Prescriber - Medical Prescriber"
+                }
+              },
+              {
+                "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation",
+                "extension": [
+                  {
+                    "url": "authorisationExpiryDate",
+                    "valueDateTime": "2023-04-07"
+                  }
+                ]
+              },
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                "extension": [
+                  {
+                    "url": "status",
+                    "valueCoding": {
+                      "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-history",
+                      "code": "R-0001",
+                      "display": "Prescription/item was cancelled"
+                    }
+                  },
+                  {
+                    "url": "statusDate",
+                    "valueDateTime": "2022-10-21T13:48:00+00:00"
+                  }
+                ]
+              },
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-DispensingInformation",
+                "extension": [
+                  {
+                    "url": "dispenseStatus",
+                    "valueCoding": {
+                      "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+                      "code": "0005",
+                      "display": "Item cancelled"
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": [
+              {
+                "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
+              }
+            ],
+            "status": "cancelled",
+            "statusReason": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-status-reason",
+                  "code": "0002",
+                  "display": "Clinical contra-indication"
+                }
+              ]
+            },
+            "intent": "reflex-order",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                    "code": "community",
+                    "display": "Community"
+                  }
+                ]
+              }
+            ],
+            "medicationCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "324252006",
+                  "display": "Azithromycin 250mg capsules"
+                }
+              ]
+            },
+            "subject": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/nhs-number",
+                "value": "9449304130"
+              },
+              "display": "Ms Marisa Stacey Twitchett"
+            },
+            "authoredOn": "2022-10-21T13:47:00+00:00",
+            "requester": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+                "value": "200102238987"
+              }
+            },
+            "basedOn": [
+              {
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+                    "extension": [
+                      {
+                        "url": "numberOfRepeatsAllowed",
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
+                      }
+                    ]
+                  }
+                ],
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+                  "value": "299c610b-f4f1-4eac-a7d7-4fb6b0556e11"
+                }
+              }
+            ],
+            "groupIdentifier": {
+              "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+              "value": "24F5DA-A83008-7EFE6Z",
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId",
+                  "valueIdentifier": {
+                    "system": "https://fhir.nhs.uk/Id/prescription",
+                    "value": "20ba5fb5-cb58-462c-923e-22d180b09356"
+                  }
+                }
+              ]
+            },
+            "courseOfTherapyType": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-course-of-therapy",
+                  "code": "continuous-repeat-dispensing",
+                  "display": "Continuous long term (repeat dispensing)"
+                }
+              ]
+            },
+            "dosageInstruction": [
+              {
+                "text": "3 times a day for 10 days",
+                "timing": {
+                  "repeat": {
+                    "frequency": 3,
+                    "period": 1,
+                    "periodUnit": "d"
+                  }
+                },
+                "route": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "26643006",
+                      "display": "Oral"
+                    }
+                  ]
+                }
+              }
+            ],
+            "dispenseRequest": {
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType",
+                  "valueCoding": {
+                    "system": "https://fhir.nhs.uk/CodeSystem/dispensing-site-preference",
+                    "code": "P1"
+                  }
+                }
+              ],
+              "validityPeriod": {
+                "start": "2022-10-21"
+              },
+			        "numberOfRepeatsAllowed": 0,
+              "quantity": {
+                "value": 30,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "428673006"
+              },
+              "expectedSupplyDuration": {
+                "value": 10,
+                "unit": "day",
+                "system": "http://unitsofmeasure.org",
+                "code": "d"
+              },
+              "performer": {
+                "identifier": {
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                  "value": "VNE51"
+                }
+              }
+            },
+            "substitution": {
+              "allowedBoolean": false
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+              "code": "0003",
+              "display": "With Dispenser - Active"
+            }
+          },
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-RepeatInformation",
+            "extension": [
+              {
+                "url": "numberOfRepeatsAllowed",
+                "valueInteger": 5
+              },
+              {
+                "url": "numberOfRepeatsIssued",
+                "valueInteger": 2
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-dispense-item-number",
+            "value": "9a0aa5fd-8865-42f5-ad67-6c83d0944ee0"
+          }
+        ],
+        "status": "cancelled",
+        "statusReasonCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-status-reason",
+              "code": "0004",
+              "display": "Prescription cancellation"
+            }
+          ]
+        },
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "324252006",
+              "display": "Azithromycin 250mg capsules"
+            }
+          ]
+        },
+        "subject": {
+          "type": "Patient",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9449304130"
+          },
+          "display": "Ms Marisa Stacey Twitchett"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "#performer"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "#m4"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+              "code": "0005",
+              "display": "Item cancelled"
+            }
+          ]
+        },
+        "quantity": {
+          "extension": [
+            {
+              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
+              "valueQuantity": {
+                "value": 0,
+                "unit": "tablet",
+                "system": "http://snomed.info/sct",
+                "code": "732936001"
+              }
+            }
+          ],
+          "value": 0,
+          "unit": "tablet",
+          "system": "http://snomed.info/sct",
+          "code": "732936001"
+        },
+		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+		    "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:2bf9f37c-d88b-4f86-ad5f-373c1416e04b",
       "resource": {
         "resourceType": "Organization",
-        "id": "organization",
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-ODS-OrganisationRelationships",
+            "extension": [
+              {
+                "url": "reimbursementAuthority",
+                "valueIdentifier": {
+                  "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                  "value": "T1450"
+                }
+              }
+            ]
+          }
+        ],
         "identifier": [
           {
             "system": "https://fhir.nhs.uk/Id/ods-organization-code",
-            "value": "VNFKT"
+            "value": "VNE51"
           }
         ],
         "address": [
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": [
-              "17 Austhorpe Road",
-              "Crossgates",
-              "Leeds"
-            ],
+            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
             "postalCode": "LS15 8BA"
           }
         ],
+        "active": true,
         "type": [
           {
             "coding": [
@@ -44,54 +1496,6 @@
             "value": "0113 3180277"
           }
         ]
-      }
-    },
-    {
-      "name": "status",
-      "valueCode": "accepted"
-    },
-    {
-      "name": "agent",
-      "resource": {
-        "resourceType": "PractitionerRole",
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "02380798431",
-            "use": "work"
-          }
-        ],
-        "identifier": [
-          {
-            "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
-            "value": "555086415105"
-          }
-        ],
-        "practitioner": {
-          "identifier": {
-            "system": "https://fhir.nhs.uk/Id/sds-user-id",
-            "value": "3415870201"
-          },
-          "display": "Jackie Clark"
-        },
-        "code": [
-          {
-            "coding": [
-              {
-                "system": "https://fhir.nhs.uk/CodeSystem/NHSDigital-SDS-JobRoleCode",
-                "code": "S8000:G8000:R8000",
-                "display": "Clinical Practitioner Access Role"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "group-identifier",
-      "valueIdentifier": {
-        "system": "https://fhir.nhs.uk/Id/prescription-order-number",
-        "value": "060CC0-A83008-5A2E6T"
       }
     }
   ]

--- a/examples/spec/dispensing/dispense-notification/repeat-primary-example-req.json
+++ b/examples/spec/dispensing/dispense-notification/repeat-primary-example-req.json
@@ -187,7 +187,11 @@
                     "extension": [
                       {
                         "url": "numberOfRepeatsAllowed",
-                        "valueUnsignedInt": 5
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
                       }
                     ]
                   }
@@ -526,7 +530,11 @@
                     "extension": [
                       {
                         "url": "numberOfRepeatsAllowed",
-                        "valueUnsignedInt": 5
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
                       }
                     ]
                   }
@@ -593,6 +601,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
+			        "numberOfRepeatsAllowed": 0,			 
               "quantity": {
                 "value": 20,
                 "unit": "tablet",
@@ -864,7 +873,11 @@
                     "extension": [
                       {
                         "url": "numberOfRepeatsAllowed",
-                        "valueUnsignedInt": 5
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
                       }
                     ]
                   }
@@ -931,6 +944,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
+			        "numberOfRepeatsAllowed": 0,				 
               "quantity": {
                 "value": 30,
                 "unit": "tablet",
@@ -973,7 +987,7 @@
               },
               {
                 "url": "numberOfRepeatsIssued",
-                "valueInteger": 1
+                "valueInteger": 2
               }
             ]
           }
@@ -1048,7 +1062,30 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+		    "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -1208,7 +1245,11 @@
                     "extension": [
                       {
                         "url": "numberOfRepeatsAllowed",
-                        "valueUnsignedInt": 5
+                        "valueInteger": 5
+                      },
+                      {
+                        "url" : "numberOfRepeatsIssued",
+                        "valueInteger" : 2
                       }
                     ]
                   }
@@ -1275,6 +1316,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
+			        "numberOfRepeatsAllowed": 0,			 
               "quantity": {
                 "value": 30,
                 "unit": "tablet",
@@ -1313,11 +1355,11 @@
             "extension": [
               {
                 "url": "numberOfRepeatsAllowed",
-                "valueInteger": 0
+                "valueInteger": 5
               },
               {
                 "url": "numberOfRepeatsIssued",
-                "valueInteger": 0
+                "valueInteger": 2
               }
             ]
           }
@@ -1392,7 +1434,30 @@
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
-        }
+        },
+		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenHandedOver": "2022-11-27T11:45:00+00:00",
+		    "dosageInstruction": [
+          {
+            "text": "20 tablets. One tablet to be taken two times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
## Summary

:ticket: [AEA-3665](https://nhsd-jira.digital.nhs.uk/browse/AEA-3665)
OAS Dispense - Notification page Try button returns 400 Bad Request

- Routine Change
- :warning: Potential issues that might be caused by this change

### Details

The Try button on the Dispense - Notification page is returning a 400 Bad Request.
I have attached the full json response.
[BadRequest.Json](https://nhsd-jira.digital.nhs.uk/secure/attachment/627040/627040_BadRequest.Json)
"diagnostics": "Expected all MedicationDispenses to have the same value for whenHandedOver.
"expression": ["Bundle.entry.resource.ofType(MedicationDispense).whenHandedOver"
[Electronic Prescription Service - FHIR API - NHS Digital](https://digital.nhs.uk/developer/api-catalogue/electronic-prescription-service-fhir#post-/FHIR/R4/$process-message-dispense-notification)

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
