### PR TITLE
AEA-3320 Update Error Response Table in the OAS for the Release Endpoint

### DIFF
--- a/packages/specification/electronic-prescription-service-api.yaml
+++ b/packages/specification/electronic-prescription-service-api.yaml
@@ -545,7 +545,7 @@ paths:
             | HTTP status | Error code                          | Description                                                                                                                                   |
             | ----------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------|
             | 400         | PRESCRIPTION_WITH_ANOTHER_DISPENSER | Another dispenser has previously released this prescription. Details of the prescription will be in OperationOutcome.contained.Organization . |
-            | 400         | RESOURCE_NOT_FOUND                  | The prescription ID specified in the parameters requested (group-identifier) did not exist.                                                                              |
+            | 400         | RESOURCE_NOT_FOUND                  | The prescription ID specified in the parameters requested (group-identifier) did not exist.                                                   |
           content:
             application/fhir+json:
               schema:

--- a/packages/specification/electronic-prescription-service-api.yaml
+++ b/packages/specification/electronic-prescription-service-api.yaml
@@ -542,10 +542,10 @@ paths:
           description: |
             An error occurred as follows:
 
-            | HTTP status | Error code                          | Description                                                                                                                     |
-            | ----------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-            | 400         | PRESCRIPTION_WITH_ANOTHER_DISPENSER | Prescription is with another dispenser. See OperationOutcome.contained.Organization for more information about owning pharmacy. |
-            | 400         | RESOURCE_NOT_FOUND                  | Prescription can not be found. Contact prescriber.                                                                              |
+            | HTTP status | Error code                          | Description                                                                                                                                   |
+            | ----------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------|
+            | 400         | PRESCRIPTION_WITH_ANOTHER_DISPENSER | Another dispenser has previously released this prescription. Details of the prescription will be in OperationOutcome.contained.Organization . |
+            | 400         | RESOURCE_NOT_FOUND                  | The prescription ID specified in the parameters requested (group-identifier) did not exist.                                                                              |
           content:
             application/fhir+json:
               schema:


### PR DESCRIPTION
## Summary

This ticket is to update the 4XX in the Response section, of the Download prescriptions - Dispensing endpoint in the OAS

https://nhsd-jira.digital.nhs.uk/browse/AEA-3320

- Routine Change

### Details

-   /FHIR/R4/Task/$release
The descriptions for the error codes have been updated as shown below:

400 	: Another dispenser has previously released this prescription. Details of the prescription will be in OperationOutcome.contained.Organization 
400 	: The prescription ID specified in the parameters requested (group-identifier) did not exist.

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
