### PR TITLE
AEA-3721 Improve README in fhir api repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ It is recommended that you use visual studio code and a devcontainer as this wil
 See https://code.visualstudio.com/docs/devcontainers/containers for details on how to set this up on your host machine.  
 There is also a workspace file in .vscode that should be opened once you have started the devcontainer. The workspace file can also be opened outside of a devcontainer if you wish.
 
+All commits must be made using [signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+
+Once the steps at the link above have been completed. Add to your ~/.gnupg/gpg.conf as below:
+
+```
+use-agent
+pinentry-mode loopback
+```
+
+and to your ~/.gnupg/gpg-agent.conf as below:
+
+```
+allow-loopback-pinentry
+```
+
+As described here:
+https://stackoverflow.com/a/59170001
+
+You will need to create the files, if they do not already exist.
+This will ensure that your VSCode bash terminal prompts you for your GPG key password.
+
+You can cache the gpg key passphrase by following instructions at https://superuser.com/questions/624343/keep-gnupg-credentials-cached-for-entire-user-session
+
 <details>
 <summary>Manual Setup</summary>
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This is a RESTful HL7® FHIR® API specification for the _Electronic Prescription Service API_.
 
 - `azure/` Defines CI/CD pipeline for the API.
+- `packages/bdd-tests/` Jest-Cucumber BDD Test Suite [README](https://github.com/NHSDigital/electronic-prescription-service-api/blob/master/packages/bdd-tests/README.md)
 - `packages/coordinator/` Deals with message translation and distribution to other services. Backend for the production EPS FHIR API.
 - `packages/models/` A common project for sharing models and loading example requests and responses for testing
 - `packages/specification/` This [Open API Specification](https://swagger.io/docs/specification/about/) describes the endpoints, methods and messages exchanged by the API. Use it to generate interactive documentation; the contract between the API and its consumers.

--- a/packages/bdd-tests/README.md
+++ b/packages/bdd-tests/README.md
@@ -19,7 +19,7 @@ npm run test -- dispenseNotificationSteps.ts
 *** You will need the privateKey file to run this. We will need to create a mock
 certificate to be able to commit the privateKey File in git
 
-*** You need to set your client_id and client_secret on your local workspace or server for the ennvironemt
+*** You need to set your client_id and client_secret on your local workspace or server for the environment
 you want to run again e.g. internal-dev or internal-qa
 e.g.
 export client_id=${client_id value}


### PR DESCRIPTION
## Summary

:ticket: Jira Reference: [AEA-3022](https://nhsd-jira.digital.nhs.uk/browse/AEA-3721)

As a developer working on EPS FHIR api
I need clear and consistent documentation
So that I know how to setup my development environment and make and test changes to the  code base

- Routine Change

### Details

The readme in the EPS FHIR api contains some outdated information, and some instructions are unclear or missing
There are also several readmes for the different packages

The readme should be clear and easy to follow
There should be clear instructions on how to set up development environment (including signed commits)
All makefile targets should have a description of what it does
All makefile targets should be able to be run successfully, or removed if they do not run and are no longer needed
All github actions should have a description of what it does
All azure pipelines should have a description of what it does
Readmes in individual packages should either be linked to from the readme at the root level, or content merged to readme at the root level

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [x] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
