### PR TITLE
AEA-3781 use new headless mode for epsat tests

### DIFF
--- a/packages/tool/e2e-tests/live.test.ts
+++ b/packages/tool/e2e-tests/live.test.ts
@@ -88,7 +88,7 @@ function buildFirefoxOptions() {
     firefoxOptions.setBinary(FIREFOX_BINARY_PATH)
   }
   if (!LOCAL_MODE) {
-    firefoxOptions.headless()
+    firefoxOptions.addArguments("--headless=new")
   }
   return firefoxOptions
 }

--- a/packages/tool/e2e-tests/live.test.ts
+++ b/packages/tool/e2e-tests/live.test.ts
@@ -88,7 +88,7 @@ function buildFirefoxOptions() {
     firefoxOptions.setBinary(FIREFOX_BINARY_PATH)
   }
   if (!LOCAL_MODE) {
-    firefoxOptions.addArguments("--headless=new")
+    firefoxOptions.addArguments("--headless")
   }
   return firefoxOptions
 }

--- a/packages/tool/e2e-tests/live.test.ts
+++ b/packages/tool/e2e-tests/live.test.ts
@@ -79,7 +79,6 @@ afterEach(async () => {
   } else {
     console.log("test succeeded")
   }
-  await driver.close()
   await driver.quit()
 })
 

--- a/packages/tool/e2e-tests/live.test.ts
+++ b/packages/tool/e2e-tests/live.test.ts
@@ -80,6 +80,7 @@ afterEach(async () => {
     console.log("test succeeded")
   }
   await driver.close()
+  await driver.quit()
 })
 
 function buildFirefoxOptions() {


### PR DESCRIPTION
## Summary

- Routine Change

### Details

 - use new headless mode for epsat e2e tests - https://www.selenium.dev/blog/2023/headless-is-going-away/