### PR TITLE
AEA-3871 Update examples and the schema to remove RunningTotal field

### DIFF
--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-01-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-01-req.json
@@ -302,17 +302,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 20,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -595,17 +584,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 20,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -888,17 +866,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1181,17 +1148,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1256,7 +1212,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+            "line": [ "17 Austhorpe Road", "Crossgates", "Leeds" ],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-02-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-02-req.json
@@ -302,17 +302,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -595,17 +584,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -888,17 +866,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 15,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 15,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1181,17 +1148,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1256,7 +1212,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+            "line": [ "17 Austhorpe Road", "Crossgates", "Leeds" ],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-03-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-03-req.json
@@ -302,17 +302,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -595,17 +584,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -888,17 +866,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 30,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 15,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1010,7 +977,6 @@
               }
             ],
             "status": "completed",
-            
             "intent": "order",
             "category": [
               {
@@ -1182,17 +1148,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1257,7 +1212,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+            "line": [ "17 Austhorpe Road", "Crossgates", "Leeds" ],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/examples/spec/dispensing/dispense-notification/acute-primary-example-04-req.json
+++ b/examples/spec/dispensing/dispense-notification/acute-primary-example-04-req.json
@@ -311,17 +311,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -604,17 +593,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -897,17 +875,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 30,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 15,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1190,17 +1157,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -1265,7 +1221,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+            "line": [ "17 Austhorpe Road", "Crossgates", "Leeds" ],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/examples/spec/dispensing/dispense-notification/eRD-primary-example-req.json
+++ b/examples/spec/dispensing/dispense-notification/eRD-primary-example-req.json
@@ -186,8 +186,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -348,17 +348,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 20,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -525,8 +514,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -593,7 +582,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
-			        "numberOfRepeatsAllowed": 0,
+              "numberOfRepeatsAllowed": 0,
               "quantity": {
                 "value": 20,
                 "unit": "tablet",
@@ -687,17 +676,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 20,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -864,8 +842,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -932,7 +910,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
-			        "numberOfRepeatsAllowed": 0,
+              "numberOfRepeatsAllowed": 0,
               "quantity": {
                 "value": 30,
                 "unit": "tablet",
@@ -1035,25 +1013,14 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
         },
-		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
         "whenHandedOver": "2022-11-27T11:45:00+00:00",
-		    "dosageInstruction": [
+        "dosageInstruction": [
           {
             "text": "20 tablets. One tablet to be taken two times a day",
             "timing": {
@@ -1232,8 +1199,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -1300,7 +1267,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
-			        "numberOfRepeatsAllowed": 0,
+              "numberOfRepeatsAllowed": 0,
               "quantity": {
                 "value": 30,
                 "unit": "tablet",
@@ -1403,25 +1370,14 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
         },
-		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
         "whenHandedOver": "2022-11-27T11:45:00+00:00",
-		    "dosageInstruction": [
+        "dosageInstruction": [
           {
             "text": "20 tablets. One tablet to be taken two times a day",
             "timing": {
@@ -1472,7 +1428,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+            "line": [ "17 Austhorpe Road", "Crossgates", "Leeds" ],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/examples/spec/dispensing/dispense-notification/repeat-primary-example-req.json
+++ b/examples/spec/dispensing/dispense-notification/repeat-primary-example-req.json
@@ -190,8 +190,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -352,17 +352,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 20,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -533,8 +522,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -601,7 +590,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
-			        "numberOfRepeatsAllowed": 0,			 
+              "numberOfRepeatsAllowed": 0,
               "quantity": {
                 "value": 20,
                 "unit": "tablet",
@@ -695,17 +684,6 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 20,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 20,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
@@ -876,8 +854,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -944,7 +922,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
-			        "numberOfRepeatsAllowed": 0,				 
+              "numberOfRepeatsAllowed": 0,
               "quantity": {
                 "value": 30,
                 "unit": "tablet",
@@ -1047,25 +1025,14 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
         },
-		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
         "whenHandedOver": "2022-11-27T11:45:00+00:00",
-		    "dosageInstruction": [
+        "dosageInstruction": [
           {
             "text": "20 tablets. One tablet to be taken two times a day",
             "timing": {
@@ -1248,8 +1215,8 @@
                         "valueInteger": 5
                       },
                       {
-                        "url" : "numberOfRepeatsIssued",
-                        "valueInteger" : 2
+                        "url": "numberOfRepeatsIssued",
+                        "valueInteger": 2
                       }
                     ]
                   }
@@ -1316,7 +1283,7 @@
               "validityPeriod": {
                 "start": "2022-10-21"
               },
-			        "numberOfRepeatsAllowed": 0,			 
+              "numberOfRepeatsAllowed": 0,
               "quantity": {
                 "value": 30,
                 "unit": "tablet",
@@ -1419,25 +1386,14 @@
           ]
         },
         "quantity": {
-          "extension": [
-            {
-              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal",
-              "valueQuantity": {
-                "value": 0,
-                "unit": "tablet",
-                "system": "http://snomed.info/sct",
-                "code": "732936001"
-              }
-            }
-          ],
           "value": 0,
           "unit": "tablet",
           "system": "http://snomed.info/sct",
           "code": "732936001"
         },
-		    "whenPrepared": "2022-11-27T11:45:00+00:00",
+        "whenPrepared": "2022-11-27T11:45:00+00:00",
         "whenHandedOver": "2022-11-27T11:45:00+00:00",
-		    "dosageInstruction": [
+        "dosageInstruction": [
           {
             "text": "20 tablets. One tablet to be taken two times a day",
             "timing": {
@@ -1488,7 +1444,7 @@
           {
             "city": "West Yorkshire",
             "use": "work",
-            "line": ["17 Austhorpe Road", "Crossgates", "Leeds"],
+            "line": [ "17 Austhorpe Road", "Crossgates", "Leeds" ],
             "postalCode": "LS15 8BA"
           }
         ],

--- a/packages/specification/schemas/components/MedicationDispense/MedicationDispense.yaml
+++ b/packages/specification/schemas/components/MedicationDispense/MedicationDispense.yaml
@@ -174,37 +174,6 @@ properties:
     type: object
     description: The amount of medication that has been dispensed. Includes unit of measure.
     properties:
-      extension:
-        type: array
-        items:
-          type: object
-          properties:
-            url:
-              type: string
-              enum:
-                - https://fhir.nhs.uk/StructureDefinition/Extension-DM-RunningTotal
-            valueQuantity:
-              type: object
-              properties:
-                value:
-                  type: number
-                  description: |
-                    The value of the measured amount. The value includes an implicit precision in the presentation of the value.
-                    A rational number with implicit precision, to a maximum of 2 decimal places with trailing zeroes removed.
-                    Do not use an IEEE type floating point type, instead use something like a true decimal, with inbuilt precision.
-                  example: 20.5
-                unit:
-                  type: string
-                  description: A human-readable representation of the unit.
-                  example: tablet
-                system:
-                  type: string
-                  description: The identification of the system that provides the coded form of the unit.
-                  enum: [http://snomed.info/sct]
-                code:
-                  type: string
-                  description: A computer processable form of the unit in some unit representation system.
-                  example: "732936001"
       value:
         type: number
         description: |


### PR DESCRIPTION
## Summary

🎫 [AEA-3871](https://nhsd-jira.digital.nhs.uk/browse/AEA-3871) Update examples and the schema to remove RunningTotal field

- Routine Change

### Details

A decision was made, via [Decision Log D026](https://nhsd-confluence.digital.nhs.uk/display/APIMC/D026%3A+Running+total+is+missing+from+repeat+dispensing+HL7v3+dispense+claim+translations), that we wouldn't support RunningTotal in FHIR as it's not used downstream anywhere / isn't mapped to HL7v3. Update examples and the schema to remove RunningTotal field.
