### PR TITLE
Chore: [AEA-4213] - Adding-SonarCloud-setup-into-repo

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -49,3 +49,9 @@ jobs:
       
       - name: run unit tests
         run: make test-api
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.organization=nhsdigital
+sonar.projectKey=NHSDigital_electronic-prescription-service-api
+sonar.host.url=https://sonarcloud.io
+
+sonar.coverage.exclusions=**/*.test.*,**/jest.config.ts,scripts/*,packages/common/testing/*
+sonar.javascript.lcov.reportPaths=packages/bdd-test/coverage/lcov.info, packages/coordinator/coverage/lcov.info, packages/e2e-tests/coverage/lcov.info, packages/tool/coverage/lcov.info
+# sonar.cpd.exclusions=packages/getMyPrescriptions/tests/test-handler.test.ts


### PR DESCRIPTION
## Summary
### Details
Adding sonar cloud scan GitHub action to FHIR repo as part of our exit from Azure DevOps.


