### PR TITLE
Docs: [AEA-4424] - Update Author, Authored and Responsible Party in the 'Create a new prescription'

### DIFF
--- a/packages/specification/schemas/components/MedicationRequest/MedicationRequest.yaml
+++ b/packages/specification/schemas/components/MedicationRequest/MedicationRequest.yaml
@@ -95,7 +95,7 @@ properties:
   requester:
     type: object
     description: |
-      Reference object to identify the Requester of a prescription. 
+      Reference object to identify the requester of a prescription. 
       A PractitionerRole resource within the Bundle must be referenced.
     properties:
       reference:

--- a/packages/specification/schemas/components/MedicationRequest/MedicationRequest.yaml
+++ b/packages/specification/schemas/components/MedicationRequest/MedicationRequest.yaml
@@ -95,7 +95,7 @@ properties:
   requester:
     type: object
     description: |
-      Reference object to identify the author of a prescription. 
+      Reference object to identify the Requester of a prescription. 
       A PractitionerRole resource within the Bundle must be referenced.
     properties:
       reference:

--- a/packages/specification/schemas/components/PractitionerRole/CreatePractitionerRole.yaml
+++ b/packages/specification/schemas/components/PractitionerRole/CreatePractitionerRole.yaml
@@ -3,8 +3,8 @@ required:
 - practitioner
 - organization
 description: |
-  Role-specific details of the author or responsible party of a prescription.
-  If for a responsible party, at least one of the practitionerRole, referenced practitioner,
+  Role-specific details of the requester or responsible practitioner of a prescription.
+  If for a responsible practitioner, at least one of the practitionerRole, referenced practitioner,
   or referenced organization must have a telecom field. Note that PractitionerRole level
   NHS BSA spurious code will take priority over supplier practitioner identifier, if present.
 properties:

--- a/packages/specification/schemas/components/Provenance/Provenance.yaml
+++ b/packages/specification/schemas/components/Provenance/Provenance.yaml
@@ -29,7 +29,7 @@ properties:
   agent:
     type: array
     description: | 
-      A reference to the prescriber who signed the prescription, i.e. the author of the prescription.
+      A reference to the prescriber who signed the prescription, i.e. the requester of the prescription.
       A PractitionerRole resource within the Bundle must be referenced. 
     items:
       type: object

--- a/packages/specification/schemas/components/_extensions/DMResponsiblePractitioner.yaml
+++ b/packages/specification/schemas/components/_extensions/DMResponsiblePractitioner.yaml
@@ -1,5 +1,5 @@
 type: object
-description: A reference to the responsible party of a prescription, where they are distinct to the prescriber who authored the prescription.
+description: A reference to the responsible practitioner of a prescription, where they are distinct to the prescriber who authored the prescription.
 properties:
   url:
     type: string
@@ -14,5 +14,5 @@ properties:
         example: urn:uuid:a5acefc1-f8ca-4989-a5ac-34ae36741466
       display: 
         type: string
-        description: The name of the responsible party.
+        description: The name of the responsible practitioner.
         example: Dr. James Smith

--- a/packages/specification/schemas/components/_extensions/DMResponsiblePractitioner.yaml
+++ b/packages/specification/schemas/components/_extensions/DMResponsiblePractitioner.yaml
@@ -1,5 +1,5 @@
 type: object
-description: A reference to the responsible practitioner of a prescription, where they are distinct to the prescriber who authored the prescription.
+description: A reference to the responsible practitioner of a prescription, where they are distinct to the prescriber who requested the prescription.
 properties:
   url:
     type: string


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Updated in the schema for Create a new prescription - Prescribing where it says 'Author' or 'Responsible Party' to 'Requester' and 'Responsible Practitioner'

## Pull Request Naming

Pull requests should be named using the following format:

```text
Docs: [AEA-4424] - Update Author, Authored and Responsible Party in the 'Create a new prescription'
```

- `Docs` - changes to documentation only. (Patch release)
