### PR TITLE
Docs: [AEA-4426] - OAS Update - Update Author, Authored and Responsible Party in the 'Mark a prescription as dispensed

### DIFF
--- a/packages/specification/schemas/components/_extensions/DMResponsiblePractitioner.yaml
+++ b/packages/specification/schemas/components/_extensions/DMResponsiblePractitioner.yaml
@@ -1,5 +1,5 @@
 type: object
-description: A reference to the responsible party of a prescription, where they are distinct to the prescriber who authored the prescription.
+description: A reference to the responsible practitioner of a prescription, where they are distinct to the prescriber who requested the prescription.
 properties:
   url:
     type: string


### PR DESCRIPTION
Updated to requester and responsible practitioner

## Summary

- Routine Change
 
### Details

Where it says 'Author' this has been changed to 'Requester' and where it says 'Responsible Party' this has been changed to Responsible Practitioner. 

## Pull Request Naming

Pull requests should be named using the following format:

```text
Docs: [AEA-4426] - OAS Update - Update Author, Authored and Responsible Party in the 'Mark a prescription as dispensed
```

- `Docs` - changes to documentation only. (Patch release)


