### PR TITLE
Update: [AEA-4540] - adding date-time string to validity period end dates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,13 +15,13 @@
   ],
   "remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" },
   // Features to add to the dev container. More info: https://containers.dev/features.
-  "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
-      "version": "latest",
-      "moby": "true",
-      "installDockerBuildx": "true"
-    }
-  },
+  // "features": {
+  //   "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+  //     "version": "latest",
+  //     "moby": "true",
+  //     "installDockerBuildx": "true"
+  //   }
+  // },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/packages/specification/schemas/components/MedicationRequest/DispenseNotificationMedicationRequest.yaml
+++ b/packages/specification/schemas/components/MedicationRequest/DispenseNotificationMedicationRequest.yaml
@@ -160,8 +160,8 @@ properties:
             description: |
               End date of an issue; capped at 12 months and cannot exceed the prescription's end date.
               Overall validity of the drug.
-            format: date
-            example: "2022-10-21"
+            format: date-time
+            example: "2022-10-21T23:59:59Z"
       expectedSupplyDuration:
         type: object
         description: |


### PR DESCRIPTION
## Summary

adding date-time string to validity period end dates

- Routine Change


### Details

The validityPeriod field in the FHIR API OAS should state that the end date should include 23:59:59 (to avoid the FHIR validation issue)
