### PR TITLE
Docs: [AEA-4409] - Update Review Date description in OAS

### DIFF
--- a/packages/specification/schemas/components/_extensions/MedicationRepeatInformation.yaml
+++ b/packages/specification/schemas/components/_extensions/MedicationRepeatInformation.yaml
@@ -16,7 +16,7 @@ properties:
           type: string
           description: |
             The review date of the prescription.
-            This is a required field for repeat and eRD prescriptions, and captures the date at which the prescriber must review the repeat medication that a patient is on.
+            This is a required field for repeat prescribing prescriptions, and captures the date at which the prescriber must review the repeat medication that a patient is on.
           enum: [authorisationExpiryDate]
         valueDateTime:
           type: string


### PR DESCRIPTION
Removed the statement that authorisationExpirydate is a required field for eRD prescriptions

## Summary

- Routine Change
