### PR TITLE
Fix: [AEA-4403] - use epsat to talk proxygen api

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -45,6 +45,7 @@ super\(\"1\.2
 
 # snapshots are fine
 ^[a-f0-9]{40}:?packages\/tool\/site\/client\/tests\/pages\/__snapshots__\/.*snap
+^packages\/tool\/site\/client\/tests\/pages\/__snapshots__\/.*snap
 
 # files that no longer exist or have been moved
 ^[a-f0-9]{40}:.*sds-api\/spine-directory-service\/sds\/lookup\/tests\/data\/my_real_server_schema\.json

--- a/.gitallowed
+++ b/.gitallowed
@@ -47,6 +47,9 @@ super\(\"1\.2
 ^[a-f0-9]{40}:?packages\/tool\/site\/client\/tests\/pages\/__snapshots__\/.*snap
 ^packages\/tool\/site\/client\/tests\/pages\/__snapshots__\/.*snap
 
+# CONFIG.sessionKey is fine
+CONFIG.sessionKey
+
 # files that no longer exist or have been moved
 ^[a-f0-9]{40}:.*sds-api\/spine-directory-service\/sds\/lookup\/tests\/data\/my_real_server_schema\.json
 ^[a-f0-9]{40}:.*sds-api\/spine-directory-service\/sds\/request\/tests\/examples\/single_device\.json
@@ -339,6 +342,8 @@ super\(\"1\.2
 ^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/app\.ts:65
 ^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/app\.ts:87
 ^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/app\.ts:227
+^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/app\.ts:54
+^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/app\.ts:76
 ^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/routes\/api\/send\.ts:150
 ^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/routes\/auth\/refresh\.ts:12
 ^[a-f0-9]{40}:packages\/tool\/site\/server\/src\/routes\/sign\/downloadSignatures\.ts:29

--- a/.github/scripts/deploy_api.sh
+++ b/.github/scripts/deploy_api.sh
@@ -146,6 +146,7 @@ echo "Removing dummy paths before publishing spec"
 jq 'del(."paths"."/FHIR/R4/$process-message")' "$SPEC_PATH" > temp.json && mv temp.json "${SPEC_PATH}"
 jq 'del(."paths"."/FHIR/R4//FHIR/R4/Task")' "$SPEC_PATH" > temp.json && mv temp.json "${SPEC_PATH}"
 jq 'del(."paths"."/FHIR/R4/$validate")' "$SPEC_PATH" > temp.json && mv temp.json "${SPEC_PATH}"
+jq 'del(."paths"."/FHIR/R4/$convert")' "$SPEC_PATH" > temp.json && mv temp.json "${SPEC_PATH}"
 
 if [[ "${APIGEE_ENVIRONMENT}" == "int" ]]; then
     echo

--- a/packages/specification/fhir-prescribing.yaml
+++ b/packages/specification/fhir-prescribing.yaml
@@ -565,6 +565,22 @@ paths:
                     $ref: examples/spec/errors/example-a-validation-error-missing-field/Response-FhirError.json
       security:
         - nhs-cis2-aal3: []
+  /FHIR/R4/$convert :
+    post:
+      operationId: convert
+      summary: dummy operation for path
+      description: |
+        this is a dummy method so things go to the backend correctly
+      parameters:
+        - $ref: "#/components/parameters/BearerAuthorization"
+        - $ref: "#/components/parameters/RoleId"
+        - $ref: "#/components/parameters/RequestID"
+        - $ref: "#/components/parameters/CorrelationID"
+      responses:
+        "200":
+          description: "Dummy response"
+      security:
+       - nhs-cis2-aal3: []
 
 components:
   securitySchemes:

--- a/packages/tool/azure/azure-release-pipeline.yml
+++ b/packages/tool/azure/azure-release-pipeline.yml
@@ -41,15 +41,12 @@ extends:
         proxy_path: sandbox
       - environment: internal-qa
         depends_on:
-          - internal_dev
           - qa_manual_approval
       - environment: sandbox
         proxy_path: sandbox
         depends_on:
-          - internal_qa
           - ptl_manual_approval
       - environment: int
         proxy_path: live
         depends_on:
-          - internal_qa
           - ptl_manual_approval

--- a/packages/tool/e2e-tests/helpers.ts
+++ b/packages/tool/e2e-tests/helpers.ts
@@ -91,7 +91,6 @@ export async function getElement(
 
 export async function sendPrescriptionUserJourney(driver: ThenableWebDriver): Promise<string> {
   await loginViaSimulatedAuthSmartcardUser(driver)
-  await setMockSigningConfig(driver)
   await createPrescription(driver)
   await loadPredefinedExamplePrescription(driver)
   await sendPrescription(driver)
@@ -101,7 +100,6 @@ export async function sendPrescriptionUserJourney(driver: ThenableWebDriver): Pr
 
 export async function sendBulkPrescriptionUserJourney(driver: ThenableWebDriver, fileInfo: FileUploadInfo, successfulResultCountExpected: number): Promise<void> {
   await loginViaSimulatedAuthSmartcardUser(driver)
-  await setMockSigningConfig(driver)
   await createPrescription(driver)
   await loadTestData(driver, fileInfo)
   await sendPrescription(driver)
@@ -123,7 +121,6 @@ export async function prescriptionIntoCanceledState(driver: ThenableWebDriver, f
 
 export async function sendPrescriptionSingleMessageUserJourney(driver: ThenableWebDriver, fileUploadInfo: FileUploadInfo): Promise<string> {
   await loginViaSimulatedAuthSmartcardUser(driver)
-  await setMockSigningConfig(driver)
   await createPrescription(driver)
   await loadTestData(driver, fileUploadInfo)
   await sendPrescription(driver)
@@ -352,16 +349,6 @@ export async function sendPrescription(driver: ThenableWebDriver): Promise<void>
   await new Promise(r => setTimeout(r, 10000))
 
   finaliseWebAction(driver, "SENDING PRESCRIPTION...")
-}
-
-export async function setMockSigningConfig(driver: ThenableWebDriver): Promise<void> {
-  await (await getElement(driver, configLink)).click()
-  await driver.wait(until.elementLocated(configPageTitle))
-  await waitForPageToRender()
-
-  await (await getElement(driver, By.name("useSigningMock"))).click()
-  await (await getElement(driver, configButton)).click()
-  await (await getElement(driver, backButton)).click()
 }
 
 export async function checkApiResult(driver: ThenableWebDriver, fhirOnly?: boolean): Promise<void> {

--- a/packages/tool/e2e-tests/prescribe/editPrescription.spec.ts
+++ b/packages/tool/e2e-tests/prescribe/editPrescription.spec.ts
@@ -7,7 +7,6 @@ import {
   loadPredefinedExamplePrescription,
   loginViaSimulatedAuthSmartcardUser,
   sendPrescription,
-  setMockSigningConfig,
   tenTimesDefaultWaitTimeout,
   viewPrescriptionUserJourney,
   waitForPageToRender
@@ -29,7 +28,6 @@ async function editPrescriptionOrganisationUserJourney(
   newOrganisation: string
 ): Promise<void> {
   await loginViaSimulatedAuthSmartcardUser(driver)
-  await setMockSigningConfig(driver)
   await createPrescription(driver)
   await loadPredefinedExamplePrescription(driver)
   await editPrescriptionOrganisation(driver, newOrganisation)

--- a/packages/tool/site/client/src/components/pageHeader.tsx
+++ b/packages/tool/site/client/src/components/pageHeader.tsx
@@ -22,7 +22,7 @@ export const PageHeader: React.FC<PageHeaderProps> = ({loggedIn}) => {
     <Header transactional>
       <Header.Container>
         <Header.Logo href={baseUrl} />
-        {loggedIn && (isInternalDev(environment) || isInternalDevSandbox(environment) || isQa(environment)) ? (
+        {loggedIn ? (
           <Header.ServiceName href={`${baseUrl}config`}>
             <div className="inline-flex">
               EPSAT - Electronic Prescription Service API Tool

--- a/packages/tool/site/client/src/components/pageHeader.tsx
+++ b/packages/tool/site/client/src/components/pageHeader.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import {useContext} from "react"
 import {Header, Images} from "nhsuk-react-components"
 import {AppContext} from "../index"
-import {isInternalDev, isInternalDevSandbox, isQa, isSandbox} from "../services/environment"
+import {isSandbox} from "../services/environment"
 import SessionTimer from "./sessionTimer"
 import styled from "styled-components"
 

--- a/packages/tool/site/client/src/pages/configPage.tsx
+++ b/packages/tool/site/client/src/pages/configPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import {useContext, useState, useEffect, useCallback} from "react"
+import {useContext, useState, useEffect} from "react"
 import {Label, Button, Fieldset, Form, Checkboxes, TextInput} from "nhsuk-react-components"
 import {AppContext} from "../index"
 import ButtonList from "../components/common/buttonList"

--- a/packages/tool/site/client/src/pages/configPage.tsx
+++ b/packages/tool/site/client/src/pages/configPage.tsx
@@ -45,7 +45,10 @@ const ConfigPage: React.FC = () => {
       .then(response => {
         if (response.status === 200) {
           const configDetails = response.data
-          if (configDetails.useSigningMock && configDetails.epsPrNumber && configDetails.signingPrNumber && configDetails.useProxygen) {
+          if (configDetails.hasOwnProperty("useSigningMock") && 
+          configDetails.hasOwnProperty("epsPrNumber") &&
+          configDetails.hasOwnProperty("signingPrNumber") && 
+          configDetails.hasOwnProperty("useProxygen")) {
             setConfigValues(response.data)
           }
         }

--- a/packages/tool/site/client/src/pages/configPage.tsx
+++ b/packages/tool/site/client/src/pages/configPage.tsx
@@ -60,7 +60,7 @@ const ConfigPage: React.FC = () => {
               <Label bold>Use Proxygen</Label>
               <Checkboxes id="useProxygen">
                 <Field id="useProxygen" name="useProxygen" type="checkbox" as={Checkboxes.Box}>
-                  Use Signing Mock
+                  Use Proxygen
                 </Field>
               </Checkboxes>
               {!formik.values.useSigningMock && !formik.values.useProxygen &&

--- a/packages/tool/site/client/src/pages/configPage.tsx
+++ b/packages/tool/site/client/src/pages/configPage.tsx
@@ -80,7 +80,7 @@ const ConfigPage: React.FC = () => {
                   width={30}
                   label="Signing PR Number"
                 />
-              }              
+              }
             </Fieldset>
             <ButtonList>
               <Button type="submit">Save</Button>

--- a/packages/tool/site/client/src/pages/configPage.tsx
+++ b/packages/tool/site/client/src/pages/configPage.tsx
@@ -7,6 +7,7 @@ import {Field, Formik} from "formik"
 import {axiosInstance} from "../requests/axiosInstance"
 import BackButton from "../components/common/backButton"
 import SuccessOrFail from "../components/common/successOrFail"
+import { isInternalDev, isInternalDevSandbox, isQa } from "../services/environment"
 
 interface ConfigFormValues {
   useSigningMock: boolean
@@ -20,9 +21,10 @@ interface ConfigResponse {
 }
 
 const ConfigPage: React.FC = () => {
-  const {baseUrl} = useContext(AppContext)
+  const {baseUrl, environment} = useContext(AppContext)
   const [configUpdateSuccess, setConfigUpdateSuccess] = useState(undefined)
   const initialValues = {useSigningMock: false, epsPrNumber: "", signingPrNumber: "", useProxygen: false}
+  const isDevOrQa = isInternalDev(environment) || isInternalDevSandbox(environment) || isQa(environment)
 
   if (configUpdateSuccess !== undefined) {
     return <>
@@ -44,26 +46,33 @@ const ConfigPage: React.FC = () => {
           <Form onSubmit={formik.handleSubmit} onReset={formik.handleReset}>
             <Label bold>EPS</Label>
             <Fieldset>
-              <Field
-                id="epsPrNumber"
-                name="epsPrNumber"
-                as={TextInput}
-                width={30}
-                label="EPS PR Number"
-              />
-              <Label bold>Signing</Label>
-              <Checkboxes id="useSigningMockCheckboxes">
-                <Field id="useSigningMock" name="useSigningMock" type="checkbox" as={Checkboxes.Box}>
-                  Use Signing Mock
-                </Field>
-              </Checkboxes>
+              {isDevOrQa &&
+                <Field
+                  id="epsPrNumber"
+                  name="epsPrNumber"
+                  as={TextInput}
+                  width={30}
+                  label="EPS PR Number"
+                />
+              }
               <Label bold>Use Proxygen</Label>
               <Checkboxes id="useProxygen">
                 <Field id="useProxygen" name="useProxygen" type="checkbox" as={Checkboxes.Box}>
-                  Use Proxygen
+                  Use Proxygen deployed APIs
                 </Field>
               </Checkboxes>
-              {!formik.values.useSigningMock && !formik.values.useProxygen &&
+              {isDevOrQa && 
+                <Label bold>Signing</Label>
+              }
+
+              {isDevOrQa && 
+                <Checkboxes id="useSigningMockCheckboxes">
+                  <Field id="useSigningMock" name="useSigningMock" type="checkbox" as={Checkboxes.Box}>
+                    Use Signing Mock
+                  </Field>
+                </Checkboxes>
+              }
+              {!formik.values.useSigningMock && isDevOrQa &&
                 <Field
                   id="signingPrNumber"
                   name="signingPrNumber"
@@ -71,7 +80,7 @@ const ConfigPage: React.FC = () => {
                   width={30}
                   label="Signing PR Number"
                 />
-              }
+              }              
             </Fieldset>
             <ButtonList>
               <Button type="submit">Save</Button>

--- a/packages/tool/site/client/src/pages/configPage.tsx
+++ b/packages/tool/site/client/src/pages/configPage.tsx
@@ -10,6 +10,7 @@ import SuccessOrFail from "../components/common/successOrFail"
 
 interface ConfigFormValues {
   useSigningMock: boolean
+  useProxygen: boolean
   epsPrNumber: string
   signingPrNumber: string
 }
@@ -21,7 +22,7 @@ interface ConfigResponse {
 const ConfigPage: React.FC = () => {
   const {baseUrl} = useContext(AppContext)
   const [configUpdateSuccess, setConfigUpdateSuccess] = useState(undefined)
-  const initialValues = {useSigningMock: false, epsPrNumber: "", signingPrNumber: ""}
+  const initialValues = {useSigningMock: false, epsPrNumber: "", signingPrNumber: "", useProxygen: false}
 
   if (configUpdateSuccess !== undefined) {
     return <>
@@ -56,7 +57,13 @@ const ConfigPage: React.FC = () => {
                   Use Signing Mock
                 </Field>
               </Checkboxes>
-              {!formik.values.useSigningMock &&
+              <Label bold>Use Proxygen</Label>
+              <Checkboxes id="useProxygen">
+                <Field id="useProxygen" name="useProxygen" type="checkbox" as={Checkboxes.Box}>
+                  Use Signing Mock
+                </Field>
+              </Checkboxes>
+              {!formik.values.useSigningMock && !formik.values.useProxygen &&
                 <Field
                   id="signingPrNumber"
                   name="signingPrNumber"

--- a/packages/tool/site/client/src/pages/loginPage.tsx
+++ b/packages/tool/site/client/src/pages/loginPage.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useState} from "react"
+import React, {useContext, useEffect, useState} from "react"
 import {Button, Label} from "nhsuk-react-components"
 import {AppContext} from "../index"
 import {axiosInstance} from "../requests/axiosInstance"
@@ -10,6 +10,12 @@ const LoginPage: React.FC<{separateAuth?: string}> = ({separateAuth}) => {
   const {baseUrl, environment} = useContext(AppContext)
 
   const [mockAuthSelected, setMockAuthSelected] = useState(false)
+  
+  useEffect(() => {
+    if (isInternalDev(environment)) {
+      setDefaultDevConfig(baseUrl)
+    }
+  }, [])
 
   if (isInt(environment)) {
     makeLoginRequest(baseUrl, separateAuth ? "user-separate" : "user-combined")
@@ -55,4 +61,10 @@ const makeLoginRequest = async (baseUrl: string, authLevel: string) => {
   redirect(`${response.data.redirectUri}`)
 }
 
+async function setDefaultDevConfig(
+  baseUrl: string
+): Promise<void> {
+  const defaultDevConfig = {useSigningMock: true, epsPrNumber: "", signingPrNumber: "", useProxygen: false}
+  await axiosInstance.post(`${baseUrl}config`, defaultDevConfig)
+}
 export default LoginPage

--- a/packages/tool/site/client/src/requests/axiosInstance.ts
+++ b/packages/tool/site/client/src/requests/axiosInstance.ts
@@ -8,8 +8,7 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     const requestId = uuidv4()
-    console.log(`making epsat request id ${requestId}`)
-    config.headers["x-epsat-request-id"] = requestId
+    config.headers["x-correlation-id"] = requestId
 
     return config
   },

--- a/packages/tool/site/client/src/requests/axiosInstance.ts
+++ b/packages/tool/site/client/src/requests/axiosInstance.ts
@@ -7,9 +7,7 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const requestId = uuidv4()
-    config.headers["x-correlation-id"] = requestId
-
+    config.headers["x-correlation-id"] = uuidv4()
     return config
   },
   (error) => {

--- a/packages/tool/site/client/src/requests/axiosInstance.ts
+++ b/packages/tool/site/client/src/requests/axiosInstance.ts
@@ -1,5 +1,21 @@
-import axios from "axios"
+import axios, {InternalAxiosRequestConfig} from "axios"
+import {v4 as uuidv4} from "uuid"
 
-export const axiosInstance = axios.create({
+const axiosInstance = axios.create({
   validateStatus: () => true
 })
+
+axiosInstance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const requestId = uuidv4()
+    console.log(`making epsat request id ${requestId}`)
+    config.headers["x-epsat-request-id"] = requestId
+
+    return config
+  },
+  (error) => {
+    return Promise.reject(Error(error))
+  }
+)
+
+export {axiosInstance}

--- a/packages/tool/site/client/tests/components/__snapshots__/pageHeader.spec.tsx.snap
+++ b/packages/tool/site/client/tests/components/__snapshots__/pageHeader.spec.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header renders when logged in 1`] = `
+"<header class="nhsuk-header nhsuk-header__transactional" role="banner">
+  <div class="nhsuk-width-container nhsuk-header__container">
+    <div class="nhsuk-header__logo nhsuk-header__transactional--logo"><a class="nhsuk-header__link" aria-label="NHS homepage" href="/"><svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100" aria-labelledby="nhsuk-logo_title">
+          <title id="nhsuk-logo_title">NHS Logo</title>
+          <path class="nhsuk-logo__background" d="M0 0h40v16H0z" fill="#005eb8"></path>
+          <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+        </svg></a></div>
+    <div class="nhsuk-header__transactional-service-name"><a class="nhsuk-header__transactional-service-name--link" href="/config">
+        <div class="inline-flex">EPSAT - Electronic Prescription Service API Tool<figure class="nhsuk-image"><img class="nhsuk-image__img sc-jtQUzJ fSmwEJ" srcset="/static/Cogs_SVG_White.svg" sizes="50px"></figure>
+        </div>
+      </a></div>
+  </div>
+  <div class="nhsuk-navigation-container">
+    <nav class="nhsuk-navigation" id="header-navigation" role="navigation">
+      <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
+        <li class="nhsuk-header__navigation-item"><a class="nhsuk-header__navigation-link" href="/">Home</a></li>
+        <li class="nhsuk-header__navigation-item"><a class="nhsuk-header__navigation-link" href="/my-prescriptions">My Prescriptions</a></li>
+        <li class="nhsuk-header__navigation-item"><a class="nhsuk-header__navigation-link" href="/logout">Logout</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>"
+`;
+
+exports[`Header renders when not logged in 1`] = `
+"<header class="nhsuk-header nhsuk-header__transactional" role="banner">
+  <div class="nhsuk-width-container nhsuk-header__container">
+    <div class="nhsuk-header__logo nhsuk-header__transactional--logo"><a class="nhsuk-header__link" aria-label="NHS homepage" href="/"><svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100" aria-labelledby="nhsuk-logo_title">
+          <title id="nhsuk-logo_title">NHS Logo</title>
+          <path class="nhsuk-logo__background" d="M0 0h40v16H0z" fill="#005eb8"></path>
+          <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+        </svg></a></div>
+    <div class="nhsuk-header__transactional-service-name"><a class="nhsuk-header__transactional-service-name--link" href="/">EPSAT - Electronic Prescription Service API Tool</a></div>
+  </div>
+</header>"
+`;

--- a/packages/tool/site/client/tests/components/pageHeader.spec.tsx
+++ b/packages/tool/site/client/tests/components/pageHeader.spec.tsx
@@ -1,0 +1,32 @@
+import {render, waitFor} from "@testing-library/react"
+import {screen} from "@testing-library/dom"
+import pretty from "pretty"
+import * as React from "react"
+import {PageHeader} from "../../src/components/pageHeader"
+import {expect} from "@jest/globals"
+import {MemoryRouter} from "react-router-dom"
+
+test("Header renders when logged in", async () => {
+  const {container} = render(
+    <MemoryRouter>
+      <PageHeader loggedIn={true}/>
+    </MemoryRouter>
+  )
+
+  expect(screen.getByText("My Prescriptions")).toBeTruthy()
+
+  expect(pretty(container.innerHTML)).toMatchSnapshot()
+})
+
+test("Header renders when not logged in", async () => {
+    const {container} = render(
+      <MemoryRouter>
+        <PageHeader loggedIn={false}/>
+      </MemoryRouter>
+    )
+  
+    expect(screen.queryByText("My Prescriptions")).toBeNull()
+  
+    expect(pretty(container.innerHTML)).toMatchSnapshot()
+})
+  

--- a/packages/tool/site/client/tests/components/pageHeader.spec.tsx
+++ b/packages/tool/site/client/tests/components/pageHeader.spec.tsx
@@ -1,4 +1,4 @@
-import {render, waitFor} from "@testing-library/react"
+import {render} from "@testing-library/react"
 import {screen} from "@testing-library/dom"
 import pretty from "pretty"
 import * as React from "react"

--- a/packages/tool/site/client/tests/pages/__snapshots__/claimPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/claimPage.spec.tsx.snap
@@ -31,9 +31,9 @@ exports[`Displays an error if prescription-order not found 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
+        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -81,9 +81,9 @@ exports[`Displays an error if previous claim not found for amend 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
+        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -131,9 +131,9 @@ exports[`Displays an error on invalid response 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
+        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/claimPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/claimPage.spec.tsx.snap
@@ -31,8 +31,9 @@ exports[`Displays an error if prescription-order not found 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -80,8 +81,9 @@ exports[`Displays an error if previous claim not found for amend 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -129,8 +131,9 @@ exports[`Displays an error on invalid response 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-blHHSb kmtnvA"><button class="nhsuk-button sc-egkSDF cXLMqO" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-egkSDF cXLMqO" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-gtLWhw hVlgjH">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
@@ -5,15 +5,15 @@ exports[`Displays config form 1`] = `
 <form><label class="nhsuk-label nhsuk-label--s">EPS</label>
   <div class="nhsuk-form-group">
     <fieldset class="nhsuk-fieldset">
-      <div class="nhsuk-form-group"><label class="nhsuk-label" id="epsPrNumber--label" for="epsPrNumber">EPS PR Number</label><input class="nhsuk-input nhsuk-input--width-30" type="text" name="epsPrNumber" id="epsPrNumber" value=""></div><label class="nhsuk-label nhsuk-label--s">Signing</label>
+      <div class="nhsuk-form-group"><label class="nhsuk-label" id="epsPrNumber--label" for="epsPrNumber">EPS PR Number</label><input class="nhsuk-input nhsuk-input--width-30" type="text" name="epsPrNumber" id="epsPrNumber" value=""></div><label class="nhsuk-label nhsuk-label--s">Use Proxygen</label>
+      <div class="nhsuk-form-group">
+        <div class="nhsuk-checkboxes" id="useProxygen">
+          <div class="nhsuk-checkboxes__item"><input name="useProxygen" id="useProxygen" type="checkbox" data-checkbox-exclusive-group="useProxygen" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useProxygen--label" for="useProxygen">Use Proxygen deployed APIs</label></div>
+        </div>
+      </div><label class="nhsuk-label nhsuk-label--s">Signing</label>
       <div class="nhsuk-form-group">
         <div class="nhsuk-checkboxes" id="useSigningMockCheckboxes">
           <div class="nhsuk-checkboxes__item"><input name="useSigningMock" id="useSigningMock" type="checkbox" data-checkbox-exclusive-group="useSigningMockCheckboxes" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useSigningMock--label" for="useSigningMock">Use Signing Mock</label></div>
-        </div>
-      </div><label class="nhsuk-label nhsuk-label--s">Use Proxygen</label>
-      <div class="nhsuk-form-group">
-        <div class="nhsuk-checkboxes" id="useProxygen">
-          <div class="nhsuk-checkboxes__item"><input name="useProxygen" id="useProxygen" type="checkbox" data-checkbox-exclusive-group="useProxygen" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useProxygen--label" for="useProxygen">Use Proxygen</label></div>
         </div>
       </div>
       <div class="nhsuk-form-group"><label class="nhsuk-label" id="signingPrNumber--label" for="signingPrNumber">Signing PR Number</label><input class="nhsuk-input nhsuk-input--width-30" type="text" name="signingPrNumber" id="signingPrNumber" value=""></div>

--- a/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
@@ -10,6 +10,11 @@ exports[`Displays config form 1`] = `
         <div class="nhsuk-checkboxes" id="useSigningMockCheckboxes">
           <div class="nhsuk-checkboxes__item"><input name="useSigningMock" id="useSigningMock" type="checkbox" data-checkbox-exclusive-group="useSigningMockCheckboxes" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useSigningMock--label" for="useSigningMock">Use Signing Mock</label></div>
         </div>
+      </div><label class="nhsuk-label nhsuk-label--s">Use Proxygen</label>
+      <div class="nhsuk-form-group">
+        <div class="nhsuk-checkboxes" id="useProxygen">
+          <div class="nhsuk-checkboxes__item"><input name="useProxygen" id="useProxygen" type="checkbox" data-checkbox-exclusive-group="useProxygen" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useProxygen--label" for="useProxygen">Use Signing Mock</label></div>
+        </div>
       </div>
       <div class="nhsuk-form-group"><label class="nhsuk-label" id="signingPrNumber--label" for="signingPrNumber">Signing PR Number</label><input class="nhsuk-input nhsuk-input--width-30" type="text" name="signingPrNumber" id="signingPrNumber" value=""></div>
     </fieldset>

--- a/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
@@ -1,6 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Displays config form 1`] = `
+exports[`Displays config form correctly in int 1`] = `
+"<h1 class="nhsuk-label-wrapper"><label class="nhsuk-label nhsuk-label--xl">Config</label></h1>
+<form><label class="nhsuk-label nhsuk-label--s">EPS</label>
+  <div class="nhsuk-form-group">
+    <fieldset class="nhsuk-fieldset"><label class="nhsuk-label nhsuk-label--s">Use Proxygen</label>
+      <div class="nhsuk-form-group">
+        <div class="nhsuk-checkboxes" id="useProxygen">
+          <div class="nhsuk-checkboxes__item"><input name="useProxygen" id="useProxygen" type="checkbox" data-checkbox-exclusive-group="useProxygen" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useProxygen--label" for="useProxygen">Use Proxygen deployed APIs</label></div>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button" aria-disabled="false" type="submit">Save</button></div>
+</form>"
+`;
+
+exports[`Displays config form correctly in internal dev 1`] = `
 "<h1 class="nhsuk-label-wrapper"><label class="nhsuk-label nhsuk-label--xl">Config</label></h1>
 <form><label class="nhsuk-label nhsuk-label--s">EPS</label>
   <div class="nhsuk-form-group">

--- a/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/configPage.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`Displays config form 1`] = `
       </div><label class="nhsuk-label nhsuk-label--s">Use Proxygen</label>
       <div class="nhsuk-form-group">
         <div class="nhsuk-checkboxes" id="useProxygen">
-          <div class="nhsuk-checkboxes__item"><input name="useProxygen" id="useProxygen" type="checkbox" data-checkbox-exclusive-group="useProxygen" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useProxygen--label" for="useProxygen">Use Signing Mock</label></div>
+          <div class="nhsuk-checkboxes__item"><input name="useProxygen" id="useProxygen" type="checkbox" data-checkbox-exclusive-group="useProxygen" value="false"><label class="nhsuk-label nhsuk-checkboxes__label" id="useProxygen--label" for="useProxygen">Use Proxygen</label></div>
         </div>
       </div>
       <div class="nhsuk-form-group"><label class="nhsuk-label" id="signingPrNumber--label" for="signingPrNumber">Signing PR Number</label><input class="nhsuk-input nhsuk-input--width-30" type="text" name="signingPrNumber" id="signingPrNumber" value=""></div>

--- a/packages/tool/site/client/tests/pages/__snapshots__/dispensePage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/dispensePage.spec.tsx.snap
@@ -22,8 +22,9 @@ exports[`Displays an error if prescription-order not found 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -71,8 +72,9 @@ exports[`Displays an error on invalid response 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/dispensePage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/dispensePage.spec.tsx.snap
@@ -22,9 +22,9 @@ exports[`Displays an error if prescription-order not found 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -72,9 +72,9 @@ exports[`Displays an error on invalid response 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/prescriptionSearchPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/prescriptionSearchPage.spec.tsx.snap
@@ -160,9 +160,9 @@ exports[`Displays an error message if summary search returns an error 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -234,9 +234,9 @@ exports[`Displays an error message if summary search returns invalid response 1`
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/prescriptionSearchPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/prescriptionSearchPage.spec.tsx.snap
@@ -160,8 +160,9 @@ exports[`Displays an error message if summary search returns an error 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -233,8 +234,9 @@ exports[`Displays an error message if summary search returns invalid response 1`
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
-  "Accept": "application/json, text/plain, */*"
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+  "Accept": "application/json, text/plain, */*",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/signPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/signPage.spec.tsx.snap
@@ -22,10 +22,11 @@ exports[`Displays error message if prepare errors present 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
   "Content-Type": "application/x-www-form-urlencoded",
-  "nhsd-identity-authentication-method": "N3_SMARTCARD"
+  "nhsd-identity-authentication-method": "N3_SMARTCARD",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -92,10 +93,11 @@ exports[`Displays error message if redirect URI not present 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
   "Content-Type": "application/x-www-form-urlencoded",
-  "nhsd-identity-authentication-method": "N3_SMARTCARD"
+  "nhsd-identity-authentication-method": "N3_SMARTCARD",
+  "x-epsat-request-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/signPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/signPage.spec.tsx.snap
@@ -22,11 +22,11 @@ exports[`Displays error message if prepare errors present 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
   "Content-Type": "application/x-www-form-urlencoded",
   "nhsd-identity-authentication-method": "N3_SMARTCARD",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>
@@ -93,11 +93,11 @@ exports[`Displays error message if redirect URI not present 1`] = `
     <details class="nhsuk-details nhsuk-expander">
       <summary class="nhsuk-details__summary"><span class="nhsuk-details__summary-text">Request Headers</span></summary>
       <div class="nhsuk-details__text">
-        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%2C%0A%20%20%22x-epsat-request-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
+        <div class="sc-egkSDF hcqWyj"><button class="nhsuk-button sc-ivxoEo krxZPo" aria-disabled="false" type="submit">Copy</button><a class="nhsuk-button sc-ivxoEo krxZPo" role="button" aria-disabled="false" draggable="false" href="data:text/xml;charset=utf-8,%7B%0A%20%20%22Accept%22%3A%20%22application%2Fjson%2C%20text%2Fplain%2C%20*%2F*%22%2C%0A%20%20%22Content-Type%22%3A%20%22application%2Fx-www-form-urlencoded%22%2C%0A%20%20%22nhsd-identity-authentication-method%22%3A%20%22N3_SMARTCARD%22%2C%0A%20%20%22x-correlation-id%22%3A%20%22test-uuid%22%0A%7D" download="message">Download</a></div><pre class="sc-dntaoT cwTwjs">{
   "Accept": "application/json, text/plain, */*",
   "Content-Type": "application/x-www-form-urlencoded",
   "nhsd-identity-authentication-method": "N3_SMARTCARD",
-  "x-epsat-request-id": "test-uuid"
+  "x-correlation-id": "test-uuid"
 }</pre>
       </div>
     </details>

--- a/packages/tool/site/client/tests/pages/__snapshots__/withdrawPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/withdrawPage.spec.tsx.snap
@@ -234,7 +234,7 @@ exports[`Withdraw Page When there are two dispense notifications should match th
   </table>
 </div>
 <form>
-  <div class="nhsuk-form-group">
+  <div class="">
     <fieldset class="nhsuk-fieldset">
       <div class="nhsuk-form-group"><label class="nhsuk-label nhsuk-label--s" id="pharmacy--label" for="pharmacy">Pharmacy withdrawing prescription</label>
         <div class="nhsuk-radios" id="pharmacy" value="VNFKT" aria-label="Pharmacy withdrawing prescription">

--- a/packages/tool/site/client/tests/pages/__snapshots__/withdrawPage.spec.tsx.snap
+++ b/packages/tool/site/client/tests/pages/__snapshots__/withdrawPage.spec.tsx.snap
@@ -234,7 +234,7 @@ exports[`Withdraw Page When there are two dispense notifications should match th
   </table>
 </div>
 <form>
-  <div class="">
+  <div class="nhsuk-form-group">
     <fieldset class="nhsuk-fieldset">
       <div class="nhsuk-form-group"><label class="nhsuk-label nhsuk-label--s" id="pharmacy--label" for="pharmacy">Pharmacy withdrawing prescription</label>
         <div class="nhsuk-radios" id="pharmacy" value="VNFKT" aria-label="Pharmacy withdrawing prescription">

--- a/packages/tool/site/client/tests/pages/claimPage.spec.tsx
+++ b/packages/tool/site/client/tests/pages/claimPage.spec.tsx
@@ -1,5 +1,6 @@
 import {waitFor} from "@testing-library/react"
 import {screen} from "@testing-library/dom"
+import {v4} from "uuid"
 import pretty from "pretty"
 import * as React from "react"
 import MockAdapter from "axios-mock-adapter"
@@ -12,6 +13,9 @@ import {axiosInstance} from "../../src/requests/axiosInstance"
 import {internalDev} from "../../src/services/environment"
 import {StaticProductInfo} from "../../src/components/claim/claimForm"
 import {MemoryRouter} from "react-router-dom"
+
+jest.mock("uuid")
+;(v4 as jest.Mock).mockImplementation(() => "test-uuid")
 
 const baseUrl = "baseUrl/"
 const prescriptionId = "7A9089-A83008-56A03J"

--- a/packages/tool/site/client/tests/pages/configPage.spec.tsx
+++ b/packages/tool/site/client/tests/pages/configPage.spec.tsx
@@ -7,12 +7,11 @@ import {AppContextValue} from "../../src"
 import {renderWithContext} from "../renderWithContext"
 import userEvent from "@testing-library/user-event"
 import {axiosInstance} from "../../src/requests/axiosInstance"
-import {internalDev} from "../../src/services/environment"
+import {int, internalDev} from "../../src/services/environment"
 import ConfigPage from "../../src/pages/configPage"
 import {MemoryRouter} from "react-router-dom"
 
 const baseUrl = "baseUrl/"
-const context: AppContextValue = {baseUrl, environment: internalDev}
 
 const configUrl = `${baseUrl}config`
 
@@ -21,25 +20,43 @@ const mock = new MockAdapter(axiosInstance)
 beforeEach(() => mock.reset())
 afterEach(() => mock.reset())
 
-test("Displays config form", async () => {
-  const container = await renderPage()
+test("Displays config form correctly in internal dev", async () => {
+  const context: AppContextValue = {baseUrl, environment: internalDev}
+  const container = await renderPage(context)
 
   expect(screen.getByText("Config")).toBeTruthy()
+  expect(screen.getByText("EPS PR Number")).toBeTruthy()
+  expect(screen.getByText("Use Proxygen deployed APIs")).toBeTruthy()
+  expect(screen.getByText("Use Signing Mock")).toBeTruthy()
+  expect(screen.getByText("Signing PR Number")).toBeTruthy()
+  expect(pretty(container.innerHTML)).toMatchSnapshot()
+})
+
+test("Displays config form correctly in int", async () => {
+  const context: AppContextValue = {baseUrl, environment: int}
+  const container = await renderPage(context)
+
+  expect(screen.getByText("Config")).toBeTruthy()
+  expect(screen.queryByText("EPS PR Number")).toBeNull()
+  expect(screen.getByText("Use Proxygen deployed APIs")).toBeTruthy()
+  expect(screen.queryByText("Use Signing Mock")).toBeNull()
+  expect(screen.queryByText("Signing PR Number")).toBeNull()
   expect(pretty(container.innerHTML)).toMatchSnapshot()
 })
 
 test("Displays config update result", async () => {
+  const context: AppContextValue = {baseUrl, environment: internalDev}
   mock.onAny(configUrl).reply(200, {
     success: true
   })
 
-  const container = await renderPage()
+  const container = await renderPage(context)
   userEvent.click(screen.getByText("Save"))
   await waitFor(() => screen.getByText(/Config Saved/))
   expect(pretty(container.innerHTML)).toMatchSnapshot()
 })
 
-async function renderPage() {
+async function renderPage(context) {
   const {container} = renderWithContext(<MemoryRouter><ConfigPage/></MemoryRouter>, context)
   await waitFor(() => screen.getByText("Config"))
   return container

--- a/packages/tool/site/client/tests/pages/dispensePage.spec.tsx
+++ b/packages/tool/site/client/tests/pages/dispensePage.spec.tsx
@@ -1,5 +1,6 @@
 import {waitFor} from "@testing-library/react"
 import {screen} from "@testing-library/dom"
+import {v4} from "uuid"
 import pretty from "pretty"
 import * as React from "react"
 import MockAdapter from "axios-mock-adapter"
@@ -11,6 +12,9 @@ import DispensePage from "../../src/pages/dispensePage"
 import {axiosInstance} from "../../src/requests/axiosInstance"
 import {internalDev} from "../../src/services/environment"
 import {MemoryRouter} from "react-router-dom"
+
+jest.mock("uuid")
+;(v4 as jest.Mock).mockImplementation(() => "test-uuid")
 
 const baseUrl = "baseUrl/"
 const prescriptionId = "7A9089-A83008-56A03J"

--- a/packages/tool/site/client/tests/pages/loginPage.spec.tsx
+++ b/packages/tool/site/client/tests/pages/loginPage.spec.tsx
@@ -14,6 +14,7 @@ import MockAdapter from "axios-mock-adapter"
 const baseUrl = "baseUrl/"
 
 const loginUrl = `${baseUrl}login`
+const configUrl = `${baseUrl}getconfig`
 
 const attendedAuthRedirectUrl = `https://attended-auth.com`
 const unattendedAuthRedirectUrl = `https://unattended-auth.com`
@@ -22,7 +23,10 @@ jest.mock("../../src/browser/navigation")
 
 const mock = new MockAdapter(axiosInstance)
 
-beforeEach(() => mock.reset())
+beforeEach(() => {
+  mock.reset()
+  mock.onAny(configUrl).reply(200)
+})
 afterEach(() => mock.reset())
 
 test("Displays user/system options in internal-dev", async () => {

--- a/packages/tool/site/client/tests/pages/prescriptionSearchPage.spec.tsx
+++ b/packages/tool/site/client/tests/pages/prescriptionSearchPage.spec.tsx
@@ -1,6 +1,7 @@
 import {waitFor} from "@testing-library/react"
 import {screen} from "@testing-library/dom"
 import pretty from "pretty"
+import {v4} from "uuid"
 import * as React from "react"
 import MockAdapter from "axios-mock-adapter"
 import userEvent from "@testing-library/user-event"
@@ -15,6 +16,9 @@ import {PrescriptionStatus} from "../../src/fhir/reference-data/valueSets"
 import {DateRangeType} from "../../src/components/prescription-tracker/dateRangeField"
 import {internalDev} from "../../src/services/environment"
 import {MemoryRouter} from "react-router-dom"
+
+jest.mock("uuid")
+;(v4 as jest.Mock).mockImplementation(() => "test-uuid")
 
 const baseUrl = "baseUrl/"
 const prescriptionId = "003D4D-A99968-4C5AAJ"

--- a/packages/tool/site/client/tests/pages/signPage.spec.tsx
+++ b/packages/tool/site/client/tests/pages/signPage.spec.tsx
@@ -1,5 +1,6 @@
 import {waitFor} from "@testing-library/react"
 import {screen} from "@testing-library/dom"
+import {v4} from "uuid"
 import pretty from "pretty"
 import * as React from "react"
 import MockAdapter from "axios-mock-adapter"
@@ -14,6 +15,9 @@ import {axiosInstance} from "../../src/requests/axiosInstance"
 import {MomentInput} from "moment"
 import {internalDev} from "../../src/services/environment"
 import {MemoryRouter} from "react-router-dom"
+
+jest.mock("uuid")
+;(v4 as jest.Mock).mockImplementation(() => "test-uuid")
 
 const baseUrl = "baseUrl/"
 const context: AppContextValue = {baseUrl, environment: internalDev}

--- a/packages/tool/site/server/src/app.ts
+++ b/packages/tool/site/server/src/app.ts
@@ -5,12 +5,7 @@ import Vision from "@hapi/vision"
 import * as inert from "@hapi/inert"
 import Yar from "@hapi/yar"
 import Cookie from "@hapi/cookie"
-import {
-  isDev,
-  isLocal,
-  isQa,
-  isSandbox
-} from "./services/environment"
+import {isLocal, isSandbox} from "./services/environment"
 import axios from "axios"
 import {CONFIG} from "./config"
 import {getSessionValue} from "./services/session"
@@ -198,9 +193,7 @@ function addViewRoutes(server: Hapi.Server) {
     server.route(addView("dose-to-text"))
   }
 
-  if (isDev(CONFIG.environment) || isLocal(CONFIG.environment) || isQa(CONFIG.environment)) {
-    server.route(addView("config"))
-  }
+  server.route(addView("config"))
 
   function addHomeView(): Hapi.ServerRoute {
     return addView("/")

--- a/packages/tool/site/server/src/routes/api/convert.ts
+++ b/packages/tool/site/server/src/routes/api/convert.ts
@@ -2,6 +2,7 @@ import Hapi, {RouteDefMethods} from "@hapi/hapi"
 import * as fhir from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
 import {getApigeeAccessTokenFromSession} from "../../services/session"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -14,7 +15,8 @@ export default [
       const epsClient = getEpsClient(accessToken, request)
 
       request.logger.debug(`Received Resource with id: ${resource.id}. Sending to Convert.`)
-      const convertedResource = await epsClient.makeConvertRequest(resource)
+      const correlationId = getCorrelationId(request)
+      const convertedResource = await epsClient.makeConvertRequest(resource, correlationId)
       request.logger.debug(`Converted ${resource.id}`)
 
       return responseToolkit.response(convertedResource).code(200)

--- a/packages/tool/site/server/src/routes/api/send.ts
+++ b/packages/tool/site/server/src/routes/api/send.ts
@@ -9,6 +9,7 @@ import {getEpsClient} from "../../services/communication/eps-client"
 import * as fhir from "fhir/r4"
 import {SignatureDownloadResponse} from "../../services/communication/signing-client"
 import {getMedicationRequests} from "../../common/getResources"
+import {getCorrelationId} from "../util"
 
 interface SuccessfulPrepareData {
   prescriptionId: string
@@ -63,6 +64,7 @@ export default [
 
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
+      const correlationId = getCorrelationId(request)
       const results = []
 
       for (const prepare of prepares) {
@@ -88,10 +90,10 @@ export default [
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let sendResponse: any
         if (prepares.length === 1) {
-          sendResponse = await epsClient.makeSendRequest(sendRequest)
-          sendRequestHl7 = await epsClient.makeConvertRequest(sendRequest)
+          sendResponse = await epsClient.makeSendRequest(sendRequest, correlationId)
+          sendRequestHl7 = await epsClient.makeConvertRequest(sendRequest, correlationId)
         } else {
-          sendResponse = await epsClient.makeSendFhirRequest(sendRequest)
+          sendResponse = await epsClient.makeSendFhirRequest(sendRequest, correlationId)
         }
 
         results.push({

--- a/packages/tool/site/server/src/routes/auth/callback.ts
+++ b/packages/tool/site/server/src/routes/auth/callback.ts
@@ -49,7 +49,7 @@ export default {
 
         return h.redirect(CONFIG.baseUrl)
       } catch (e) {
-        console.log(`Callback failed: ${e}`)
+        request.logger.error(`Callback failed: ${e}`)
         return h.response({error: e})
       }
     }

--- a/packages/tool/site/server/src/routes/auth/login.ts
+++ b/packages/tool/site/server/src/routes/auth/login.ts
@@ -101,7 +101,7 @@ export default {
       const scopes = ["openid", "profile"]
       const redirectUri = getRedirectUri(authorizationUri, CONFIG.cis2AppClientId, callbackUri, scopes)
 
-      console.log(`Redirecting browser to: ${redirectUri}`)
+      request.logger.info(`Redirecting browser to: ${redirectUri}`)
       return h.response({redirectUri})
     }
 
@@ -110,7 +110,7 @@ export default {
       const authorizationUri = `${CONFIG.publicApigeeHost}/oauth2/authorize`
       const redirectUri = getRedirectUri(authorizationUri, CONFIG.apigeeAppClientId, callbackUri)
 
-      console.log(`Redirecting browser to: ${redirectUri}`)
+      request.logger.info(`Redirecting browser to: ${redirectUri}`)
       return h.response({redirectUri})
     }
 
@@ -118,7 +118,7 @@ export default {
     const authorizationUri = `${CONFIG.publicApigeeHost}/oauth2-mock/authorize`
     const redirectUri = getRedirectUri(authorizationUri, CONFIG.apigeeAppClientId, callbackUri)
 
-    console.log(`Redirecting browser to: ${redirectUri}`)
+    request.logger.info(`Redirecting browser to: ${redirectUri}`)
     return h.response({redirectUri})
   }
 }

--- a/packages/tool/site/server/src/routes/config/config.ts
+++ b/packages/tool/site/server/src/routes/config/config.ts
@@ -8,11 +8,13 @@ export default {
     const payload = request.payload as {
       useSigningMock: boolean,
       epsPrNumber: string,
-      signingPrNumber: string
+      signingPrNumber: string,
+      useProxygen: boolean
     }
     setSessionValue("use_signing_mock", payload.useSigningMock, request)
     setSessionValue("eps_pr_number", payload.epsPrNumber, request)
     setSessionValue("signing_pr_number", payload.signingPrNumber, request)
+    setSessionValue("use_proxygen", payload.useProxygen, request)
     return h.response({success: true}).code(200)
   }
 }

--- a/packages/tool/site/server/src/routes/config/config.ts
+++ b/packages/tool/site/server/src/routes/config/config.ts
@@ -1,20 +1,39 @@
 import Hapi, {RouteDefMethods} from "@hapi/hapi"
-import {setSessionValue} from "../../services/session"
+import {getSessionValue, setSessionValue} from "../../services/session"
 
-export default {
-  method: "POST" as RouteDefMethods,
-  path: "/config",
-  handler: async (request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Hapi.ResponseObject> => {
-    const payload = request.payload as {
+export default [
+  {
+    method: "POST" as RouteDefMethods,
+    path: "/config",
+    handler: async (request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Hapi.ResponseObject> => {
+      const payload = request.payload as {
       useSigningMock: boolean,
       epsPrNumber: string,
       signingPrNumber: string,
       useProxygen: boolean
     }
-    setSessionValue("use_signing_mock", payload.useSigningMock, request)
-    setSessionValue("eps_pr_number", payload.epsPrNumber, request)
-    setSessionValue("signing_pr_number", payload.signingPrNumber, request)
-    setSessionValue("use_proxygen", payload.useProxygen, request)
-    return h.response({success: true}).code(200)
+      setSessionValue("use_signing_mock", payload.useSigningMock, request)
+      setSessionValue("eps_pr_number", payload.epsPrNumber, request)
+      setSessionValue("signing_pr_number", payload.signingPrNumber, request)
+      setSessionValue("use_proxygen", payload.useProxygen, request)
+      return h.response({success: true}).code(200)
+    }
+  },
+  {
+    method: "GET" as RouteDefMethods,
+    path: "/getconfig",
+    handler: async (request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Hapi.ResponseObject> => {
+      const useSigningMock = getSessionValue("use_signing_mock", request) as boolean
+      const epsPrNumber = getSessionValue("eps_pr_number", request) as string
+      const signingPrNumber = getSessionValue("signing_pr_number", request) as string
+      const useProxygen = getSessionValue("use_proxygen", request) as boolean
+      const response = {
+        useSigningMock,
+        epsPrNumber,
+        signingPrNumber,
+        useProxygen
+      }
+      return h.response(response).code(200)
+    }
   }
-}
+]

--- a/packages/tool/site/server/src/routes/dispense/claim.ts
+++ b/packages/tool/site/server/src/routes/dispense/claim.ts
@@ -8,6 +8,7 @@ import {
 } from "../../services/session"
 import {Claim} from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -19,8 +20,9 @@ export default [
       const claimRequest = payload.claim
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const claimResponse = await epsClient.makeClaimRequest(claimRequest)
-      const claimResponseHl7 = await epsClient.makeConvertRequest(claimRequest)
+      const correlationId = getCorrelationId(request)
+      const claimResponse = await epsClient.makeClaimRequest(claimRequest, correlationId)
+      const claimResponseHl7 = await epsClient.makeConvertRequest(claimRequest, correlationId)
       const success = claimResponse.statusCode === 200
 
       if (success) {

--- a/packages/tool/site/server/src/routes/dispense/dispense.ts
+++ b/packages/tool/site/server/src/routes/dispense/dispense.ts
@@ -8,6 +8,7 @@ import {
 } from "../../services/session"
 import * as fhir from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
+import {getCorrelationId} from "../util"
 
 export interface MedicationDispense extends fhir.MedicationDispense {
   contained: Array<MedicationRequest | fhir.PractitionerRole>
@@ -27,8 +28,11 @@ export default [
 
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const dispenseNotificationResponse = await epsClient.makeSendRequest(dispenseNotificationRequest)
-      const dispenseNotificationRequestHl7 = await epsClient.makeConvertRequest(dispenseNotificationRequest)
+      const correlationId = getCorrelationId(request)
+      const dispenseNotificationResponse = await epsClient.makeSendRequest(dispenseNotificationRequest, correlationId)
+      const dispenseNotificationRequestHl7 = await epsClient.makeConvertRequest(
+        dispenseNotificationRequest, correlationId
+      )
       const success = dispenseNotificationResponse.statusCode === 200
       if (success) {
         const medicationDispense = dispenseNotificationRequest?.entry

--- a/packages/tool/site/server/src/routes/dispense/release.ts
+++ b/packages/tool/site/server/src/routes/dispense/release.ts
@@ -15,6 +15,7 @@ import {
 } from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
 import {getMedicationRequests} from "../../common/getResources"
+import {getCorrelationId} from "../util"
 
 interface DispenserDetails {
   odsCode: string
@@ -30,8 +31,9 @@ export default [
       const releaseRequest = request.payload as Parameters
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const releaseResponse = await epsClient.makeReleaseRequest(releaseRequest)
-      const releaseRequestHl7 = await epsClient.makeConvertRequest(releaseRequest)
+      const correlationId = getCorrelationId(request)
+      const releaseResponse = await epsClient.makeReleaseRequest(releaseRequest, correlationId)
+      const releaseRequestHl7 = await epsClient.makeConvertRequest(releaseRequest, correlationId)
 
       let withDispenser: DispenserDetails | undefined = undefined
       const releasedPrescriptionIds: Array<string> = []

--- a/packages/tool/site/server/src/routes/dispense/return.ts
+++ b/packages/tool/site/server/src/routes/dispense/return.ts
@@ -2,6 +2,7 @@ import Hapi, {RouteDefMethods} from "@hapi/hapi"
 import {getApigeeAccessTokenFromSession, removeFromSessionValue} from "../../services/session"
 import {Task} from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -11,8 +12,9 @@ export default [
       const releaseRequest = request.payload as Task
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const returnResponse = await epsClient.makeReturnRequest(releaseRequest)
-      const returnRequestHl7 = await epsClient.makeConvertRequest(releaseRequest)
+      const correlationId = getCorrelationId(request)
+      const returnResponse = await epsClient.makeReturnRequest(releaseRequest, correlationId)
+      const returnRequestHl7 = await epsClient.makeConvertRequest(releaseRequest, correlationId)
       const success = returnResponse.statusCode === 200
       if (success) {
         removeFromSessionValue("released_prescription_ids", releaseRequest.groupIdentifier?.value, request)

--- a/packages/tool/site/server/src/routes/dispense/withdraw.ts
+++ b/packages/tool/site/server/src/routes/dispense/withdraw.ts
@@ -9,6 +9,7 @@ import {
 } from "../../services/session"
 import {Bundle, Task} from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -18,8 +19,9 @@ export default [
       const withdrawRequest = request.payload as Task
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const withdrawResponse = await epsClient.makeWithdrawRequest(withdrawRequest)
-      const withdrawRequestHl7 = await epsClient.makeConvertRequest(withdrawRequest)
+      const correlationId = getCorrelationId(request)
+      const withdrawResponse = await epsClient.makeWithdrawRequest(withdrawRequest, correlationId)
+      const withdrawRequestHl7 = await epsClient.makeConvertRequest(withdrawRequest, correlationId)
       const success = withdrawResponse.statusCode === 200
       if (success) {
         const prescriptionId = withdrawRequest.groupIdentifier?.value

--- a/packages/tool/site/server/src/routes/dose-to-text.ts
+++ b/packages/tool/site/server/src/routes/dose-to-text.ts
@@ -2,6 +2,7 @@ import Hapi, {RouteDefMethods} from "@hapi/hapi"
 import {getApigeeAccessTokenFromSession} from "../services/session"
 import {getEpsClient} from "../services/communication/eps-client"
 import * as fhir from "fhir/r4"
+import {getCorrelationId} from "./util"
 
 export interface DosageTranslation {
   identifier: Array<fhir.Identifier>
@@ -16,7 +17,8 @@ export default [
       const doseToTextRequest = request.payload as fhir.FhirResource
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const doseToTextResponse = await epsClient.makeDoseToTextRequest(doseToTextRequest)
+      const correlationId = getCorrelationId(request)
+      const doseToTextResponse = await epsClient.makeDoseToTextRequest(doseToTextRequest, correlationId)
       const epsResponse = doseToTextResponse.fhirResponse as DosageTranslationArray
       const doseToTextResults = epsResponse ?? []
       const success = doseToTextResponse.statusCode === 200

--- a/packages/tool/site/server/src/routes/index.ts
+++ b/packages/tool/site/server/src/routes/index.ts
@@ -77,7 +77,7 @@ const routes: Array<ServerRoute> = isSandbox(CONFIG.environment)
     oauthCallbackRoute
   ]
   : [
-    configRoutes,
+    ...configRoutes,
     ...authRoutes,
     ...apiRoutes,
     ...stateRoutes,

--- a/packages/tool/site/server/src/routes/prescribe/cancel.ts
+++ b/packages/tool/site/server/src/routes/prescribe/cancel.ts
@@ -2,6 +2,7 @@ import Hapi, {RouteDefMethods} from "@hapi/hapi"
 import {Bundle} from "fhir/r4"
 import {getEpsClient} from "../../services/communication/eps-client"
 import {getApigeeAccessTokenFromSession} from "../../services/session"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -11,8 +12,9 @@ export default [
       const cancelRequest = request.payload as Bundle
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const cancelResponse = await epsClient.makeSendRequest(cancelRequest)
-      const cancelResponseHl7 = await epsClient.makeConvertRequest(cancelRequest)
+      const correlationId = getCorrelationId(request)
+      const cancelResponse = await epsClient.makeSendRequest(cancelRequest, correlationId)
+      const cancelResponseHl7 = await epsClient.makeConvertRequest(cancelRequest, correlationId)
       const success = cancelResponse.statusCode === 200
       return responseToolkit.response({
         success: success,

--- a/packages/tool/site/server/src/routes/sign/uploadSignatures.ts
+++ b/packages/tool/site/server/src/routes/sign/uploadSignatures.ts
@@ -3,7 +3,7 @@ import {getSigningClient} from "../../services/communication/signing-client"
 import {getEpsClient} from "../../services/communication/eps-client"
 import {getApigeeAccessTokenFromSession, getSessionValue, setSessionValue} from "../../services/session"
 import * as fhir from "fhir/r4"
-import {getSessionPrescriptionIdsArray} from "../util"
+import {getCorrelationId, getSessionPrescriptionIdsArray} from "../util"
 
 export default [
   {
@@ -16,9 +16,10 @@ export default [
       const prescriptionIds = getSessionPrescriptionIdsArray(request)
       const successfulPreparePrescriptionIds = []
       const signInHeaders = request.headers["nhsd-identity-authentication-method"]
+      const correlationId = getCorrelationId(request)
       for (const id of prescriptionIds) {
         const prepareRequest = getSessionValue(`prepare_request_${id}`, request)
-        const prepareResponse = await epsClient.makePrepareRequest(prepareRequest)
+        const prepareResponse = await epsClient.makePrepareRequest(prepareRequest, correlationId)
         setSessionValue(`prepare_response_${id}`, prepareResponse, request)
         if (!prepareResponseIsError(prepareResponse)) {
           successfulPreparePrescriptionIds.push(id)

--- a/packages/tool/site/server/src/routes/tracker/tracker.ts
+++ b/packages/tool/site/server/src/routes/tracker/tracker.ts
@@ -1,6 +1,7 @@
 import Hapi, {RouteDefMethods} from "@hapi/hapi"
 import {getEpsClient} from "../../services/communication/eps-client"
 import {getApigeeAccessTokenFromSession} from "../../services/session"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -9,7 +10,8 @@ export default [
     handler: async (request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<Hapi.ResponseObject> => {
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const response = await epsClient.makeGetTaskTrackerRequest(request.query)
+      const correlationId = getCorrelationId(request)
+      const response = await epsClient.makeGetTaskTrackerRequest(request.query, correlationId)
       return h.response(response).code(200)
     }
   }

--- a/packages/tool/site/server/src/routes/util.ts
+++ b/packages/tool/site/server/src/routes/util.ts
@@ -1,5 +1,6 @@
 import Hapi from "@hapi/hapi"
 import {getSessionValue} from "../services/session"
+import * as uuid from "uuid"
 
 export type PrescriptionId = {
   bundleId: string | undefined
@@ -12,4 +13,9 @@ export function getUtcEpochSeconds(): number {
 
 export function getSessionPrescriptionIdsArray(request: Hapi.Request): Array<string> {
   return getSessionValue("prescription_ids", request).map((id: PrescriptionId) => id.prescriptionId)
+}
+
+export function getCorrelationId(request: Hapi.Request): string {
+  const correlationId = request.headers["x-correlation-id"]
+  return correlationId || uuid.v4()
 }

--- a/packages/tool/site/server/src/routes/validate/validator.ts
+++ b/packages/tool/site/server/src/routes/validate/validator.ts
@@ -2,6 +2,7 @@ import Hapi, {RouteDefMethods} from "@hapi/hapi"
 import {getApigeeAccessTokenFromSession} from "../../services/session"
 import {getEpsClient} from "../../services/communication/eps-client"
 import {FhirResource} from "fhir/r4"
+import {getCorrelationId} from "../util"
 
 export default [
   {
@@ -11,7 +12,8 @@ export default [
       const validateRequest = request.payload as FhirResource
       const accessToken = getApigeeAccessTokenFromSession(request)
       const epsClient = getEpsClient(accessToken, request)
-      const validateResponse = await epsClient.makeValidateRequest(validateRequest)
+      const correlationId = getCorrelationId(request)
+      const validateResponse = await epsClient.makeValidateRequest(validateRequest, correlationId)
       const sendResult = {
         success: !validateResponse.fhirResponse.issue.some(issue => issue.severity === "error"),
         request: validateRequest,

--- a/packages/tool/site/server/src/services/communication/eps-client.ts
+++ b/packages/tool/site/server/src/services/communication/eps-client.ts
@@ -194,7 +194,7 @@ class EpsClient {
     const useProxygen = getSessionValue("use_proxygen", this.request)
     let replacementString = "electronic-prescriptions"
     if (useProxygen) {
-      replacementString = api==="prescribing" ? "fhir-prescribing" : "fhir-dispensing"
+      replacementString = api==="prescribe" ? "fhir-prescribing" : "fhir-dispensing"
     }
     return prNumber
       ? `${replacementString}-pr-${prNumber}`

--- a/packages/tool/site/server/src/services/communication/eps-client.ts
+++ b/packages/tool/site/server/src/services/communication/eps-client.ts
@@ -87,39 +87,39 @@ class EpsClient {
 
   async makeGetTaskTrackerRequest(query: QueryParams): Promise<Bundle | OperationOutcome> {
     const urlSearchParams = getUrlSearchParams(query)
-    return (await this.makeApiCall<Bundle | OperationOutcome>("Task", undefined, urlSearchParams)).data
+    return (await this.makeApiCall<Bundle | OperationOutcome>("Task", "prescribe", undefined, urlSearchParams)).data
   }
 
   async makePrepareRequest(body: Bundle): Promise<Parameters | OperationOutcome> {
-    return (await this.makeApiCall<Parameters | OperationOutcome>("$prepare", body)).data
+    return (await this.makeApiCall<Parameters | OperationOutcome>("$prepare", "prescribe", body)).data
   }
 
   async makeSendRequest(body: Bundle): Promise<EpsResponse<OperationOutcome>> {
-    return await this.getEpsResponse("$process-message", body)
+    return await this.getEpsResponse("$process-message", "prescribe", body)
   }
 
   async makeSendFhirRequest(body: Bundle): Promise<EpsResponse<OperationOutcome>> {
-    return await this.getEpsResponse("$process-message", body, undefined, true)
+    return await this.getEpsResponse("$process-message", "prescribe", body, undefined, true)
   }
 
   async makeReleaseRequest(body: Parameters): Promise<EpsResponse<Parameters | OperationOutcome>> {
-    return await this.getEpsResponse("Task/$release", body)
+    return await this.getEpsResponse("Task/$release", "dispense", body)
   }
 
   async makeReturnRequest(body: Task): Promise<EpsResponse<OperationOutcome>> {
-    return await this.getEpsResponse("Task", body)
+    return await this.getEpsResponse("Task", "dispense", body)
   }
 
   async makeWithdrawRequest(body: Task): Promise<EpsResponse<OperationOutcome>> {
-    return await this.getEpsResponse("Task", body)
+    return await this.getEpsResponse("Task", "dispense", body)
   }
 
   async makeClaimRequest(body: Claim): Promise<EpsResponse<OperationOutcome>> {
-    return await this.getEpsResponse("Claim", body)
+    return await this.getEpsResponse("Claim", "dispense", body)
   }
 
   async makePingRequest(): Promise<Ping> {
-    const basePath = this.getBasePath()
+    const basePath = this.getBasePath("prescribe")
     const url = `${CONFIG.apigeeEgressHost}/${basePath}/_ping`
     return (await axiosInstance.get<Ping>(url)).data
   }
@@ -127,20 +127,21 @@ class EpsClient {
   async makeValidateRequest(body: FhirResource): Promise<EpsResponse<OperationOutcome>> {
     const requestId = uuid.v4()
     // eslint-disable-next-line max-len
-    const response = await this.makeApiCall<OperationOutcome>("$validate", body, undefined, requestId, {"x-show-validation-warnings": "true"})
+    const response = await this.makeApiCall<OperationOutcome>("$validate", "prescribe", body, undefined, requestId, {"x-show-validation-warnings": "true"})
     const statusCode = response.status
     const fhirResponse = response.data
     return {statusCode, fhirResponse}
   }
 
   async makeConvertRequest(body: FhirResource): Promise<string> {
-    const response = (await this.makeApiCall<string | OperationOutcome>("$convert", body)).data
+    const response = (await this.makeApiCall<string | OperationOutcome>("$convert", "prescribe", body)).data
     return typeof response === "string" ? response : JSON.stringify(response, null, 2)
   }
 
   async makeDoseToTextRequest(body: FhirResource): Promise<EpsResponse<DosageTranslationArray>> {
     const requestId = uuid.v4()
-    const response = await this.makeApiCall<DosageTranslationArray>("$dose-to-text", body, undefined, requestId)
+    const response = await this.makeApiCall<DosageTranslationArray>(
+      "$dose-to-text", "prescribe", body, undefined, requestId)
     const statusCode = response.status
     const doseToTextResponse = response.data
     return {statusCode, fhirResponse: doseToTextResponse}
@@ -148,29 +149,31 @@ class EpsClient {
 
   private async getEpsResponse<T>(
     endpoint: string,
+    api: string,
     body?: FhirResource,
     params?: URLSearchParams,
     fhirResponseOnly?: boolean
   ) {
     const requestId = uuid.v4()
-    const response = await this.makeApiCall<T>(endpoint, body, params, requestId)
+    const response = await this.makeApiCall<T>(endpoint, api, body, params, requestId)
     const statusCode = response.status
     const fhirResponse = response.data
     const spineResponse = fhirResponseOnly
       ? ""
       // eslint-disable-next-line max-len
-      : (await this.makeApiCall<string | OperationOutcome>(endpoint, body, params, requestId, {"x-raw-response": "true"})).data
+      : (await this.makeApiCall<string | OperationOutcome>(endpoint, api, body, params, requestId, {"x-raw-response": "true"})).data
     return {statusCode, fhirResponse, spineResponse: this.asString(spineResponse)}
   }
 
   private async makeApiCall<T>(
     path: string,
+    api: string,
     body?: unknown,
     params?: URLSearchParams,
     requestId?: string,
     additionalHeaders?: RawAxiosRequestHeaders
   ): Promise<AxiosResponse<T>> {
-    const basePath = this.getBasePath()
+    const basePath = this.getBasePath(api)
     const url = `${CONFIG.apigeeEgressHost}/${basePath}/FHIR/R4/${path}`
     const headers: RawAxiosRequestHeaders = this.getHeaders(requestId)
     if (additionalHeaders) {
@@ -186,11 +189,16 @@ class EpsClient {
     })
   }
 
-  protected getBasePath(): string {
+  protected getBasePath(api: string): string {
     const prNumber = getSessionValue("eps_pr_number", this.request)
+    const useProxygen = getSessionValue("use_proxygen", this.request)
+    let replacementString = "electronic-prescriptions"
+    if (useProxygen) {
+      replacementString = api==="prescribing" ? "fhir-prescribing" : "fhir-dispensing"
+    }
     return prNumber
-      ? `electronic-prescriptions-pr-${prNumber}`
-      : `${CONFIG.basePath}`.replace("eps-api-tool", "electronic-prescriptions")
+      ? `${replacementString}-pr-${prNumber}`
+      : `${CONFIG.basePath}`.replace("eps-api-tool", replacementString)
   }
 
   protected getHeaders(requestId: string | undefined): RawAxiosRequestHeaders {

--- a/packages/tool/site/server/src/services/communication/eps-client.ts
+++ b/packages/tool/site/server/src/services/communication/eps-client.ts
@@ -49,7 +49,7 @@ interface ApiCall {
   body?: unknown,
   params?: URLSearchParams,
   requestId?: string,
-  correlationId? : string,
+  correlationId : string,
   additionalHeaders?: RawAxiosRequestHeaders
 }
 

--- a/packages/tool/site/server/src/services/communication/eps-client.ts
+++ b/packages/tool/site/server/src/services/communication/eps-client.ts
@@ -118,7 +118,7 @@ class EpsClient {
     const urlSearchParams = getUrlSearchParams(query)
     return (await this.makeApiCall<Bundle | OperationOutcome>({
       path: "Task",
-      apiType: ApiType.Prescribing,
+      apiType: ApiType.Dispensing,
       params: urlSearchParams,
       correlationId
     })).data

--- a/packages/tool/site/server/src/services/communication/eps-client.ts
+++ b/packages/tool/site/server/src/services/communication/eps-client.ts
@@ -69,7 +69,7 @@ interface GetEpsResponseParameters {
 
 class EpsClient {
   private request: Hapi.Request
-  private axiosInstance: AxiosInstance
+  private readonly axiosInstance: AxiosInstance
 
   constructor(request: Hapi.Request) {
     this.request = request

--- a/packages/tool/site/server/src/services/session.ts
+++ b/packages/tool/site/server/src/services/session.ts
@@ -9,9 +9,9 @@ export function getSessionValue(key: string, request: Hapi.Request): any {
   const sessionValue = request.yar.get(key)
   if (isLocal(CONFIG.environment)) {
     if (sessionValue === null) {
-      console.error(`Failed to retrieve session value for key: ${key}`)
+      request.logger.error(`Failed to retrieve session value for key: ${key}`)
     } else {
-      console.log(`Retrieved ${key} from session with value: ${JSON.stringify(sessionValue)}`)
+      request.logger.info(`Retrieved ${key} from session with value: ${JSON.stringify(sessionValue)}`)
     }
   }
   if (sessionValue && Object.keys(sessionValue).length === 1 && Object.keys(sessionValue)[0] === "arrayValues") {
@@ -30,7 +30,7 @@ export function setSessionValue(key: string, value: unknown, request: Hapi.Reque
     value = {arrayValues: value}
   }
   if (isLocal(CONFIG.environment)) {
-    console.log(`Saving ${key} to session with value: ${JSON.stringify(value)}`)
+    request.logger.info(`Saving ${key} to session with value: ${JSON.stringify(value)}`)
   }
   request.yar.set(key, value)
 }


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- have config in epsat to talk to proxygen api
- pass an x-correlation-id from epsat client to epsat backend
- pass x-correlation-id from epsat backend to downstream api with a new x-request-id
- remove console.log
- add convert endpoint to PTL prescribing as its used by epsat
- set use mock signing on by default in dev