### PR TITLE
Fix: [AEA-0000] - do not require asid in qa apim deployment

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -69,8 +69,6 @@ extends:
         secret_file_ids:
           - ptl/api-deployment/electronic-prescription-api/int/eps_int_test_certificate.crt
           - ptl/api-deployment/electronic-prescription-api/int/eps_int_test_private.key
-        jinja_templates:
-          REQUIRE_ASID: true
         post_deploy:
           - template: ./templates/run_tests.yml
       - environment: ref


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- do not require asid in qa for apim deploymentss