### PR TITLE
Fix: [AEA-5057] - log payload on error or warning response

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -20,6 +20,19 @@ const token = await getAuthToken()
 throw new Error\(`Cannot retrieve auth token: \${requestUrl} returned \${response.data}`\)
 throw `Could not retrieve token: \${result.data}
 
+# ignore dummy account id in cdk.json
+ "accountId": "766544332211"
+
+# ignore cidr and dummy account id in cdk.context.json
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"vpc-provider:account=766544332211:filter.vpc-id=vpc-53412ffeeddccbb12:region=eu-west-2:returnAsymmetricSubnets=true"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"vpcCidrBlock": "10\.190\.0\.0\/16"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"cidr": "10\.190\.96\.0\/19"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"cidr": "10\.190\.128\.0\/19"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"cidr": "10\.190\.160\.0\/19"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"cidr": "10\.190\.0\.0\/19"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"cidr": "10\.190\.32\.0\/19"
+^([a-f0-9]{40}:)?cdk\.context\.json:.*"cidr": "10\.190\.64\.0\/19"
+
 # ignore all xml and json examples, tests, resources
 ^[a-f0-9]{40}:examples\/.*\.xml:\d+:
 ^[a-f0-9]{40}:examples\/.*\.json:\d+:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5047,6 +5047,15 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/split2": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@types/split2/-/split2-4.2.3.tgz",
+      "integrity": "sha512-59OXIlfUsi2k++H6CHgUQKEb2HKRokUA39HY1i1dS8/AIcqVjtAAFdf8u+HxTWK/4FUHMJQlKSZ4I6irCBJ1Zw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -17567,10 +17576,12 @@
         "@types/lossless-json": "^2.0.0",
         "@types/module-alias": "^2.0.4",
         "@types/mustache": "^4.2.5",
+        "@types/split2": "^4.2.3",
         "@types/uuid": "^10.0.0",
         "@types/xml-c14n": "^0.0.3",
         "axios-mock-adapter": "^2.1.0",
         "jest-expect-message": "^1.1.3",
+        "split2": "^4.2.0",
         "ts-node-dev": "^2.0.0"
       },
       "engines": {

--- a/packages/coordinator/package.json
+++ b/packages/coordinator/package.json
@@ -51,10 +51,12 @@
     "@types/lossless-json": "^2.0.0",
     "@types/module-alias": "^2.0.4",
     "@types/mustache": "^4.2.5",
+    "@types/split2": "^4.2.3",
     "@types/uuid": "^10.0.0",
     "@types/xml-c14n": "^0.0.3",
     "axios-mock-adapter": "^2.1.0",
     "jest-expect-message": "^1.1.3",
+    "split2": "^4.2.0",
     "ts-node-dev": "^2.0.0"
   },
   "_moduleAliases": {

--- a/packages/coordinator/src/server.ts
+++ b/packages/coordinator/src/server.ts
@@ -56,7 +56,8 @@ const configureLogging = async (server: Hapi.Server) => {
     }),
     // Redact Authorization headers, see https://getpino.io/#/docs/redaction
     redact: ["req.headers.authorization"],
-    wrapSerializers: false
+    wrapSerializers: false,
+    mergeHapiLogData: true
   })
 }
 

--- a/packages/coordinator/src/server.ts
+++ b/packages/coordinator/src/server.ts
@@ -8,9 +8,12 @@ import {
   switchContentTypeForSmokeTest
 } from "./utils/server-extensions"
 
-export const createServer = ({collectLogs}: {collectLogs?: boolean}): Hapi.Server => {
+export const createServer = (
+  {collectLogs}: {collectLogs?: boolean},
+  port: number
+): Hapi.Server => {
   const server = Hapi.server({
-    port: 9000,
+    port: port,
     host: "0.0.0.0",
     routes: {
       cors: true, // Won't run as Apigee hosted target without this
@@ -67,7 +70,7 @@ const configureLogging = async (server: Hapi.Server) => {
 }
 
 export const init = async (): Promise<void> => {
-  const server = createServer({})
+  const server = createServer({}, 9000)
   await configureLogging(server)
   await server.start()
   server.log("info", `Server running on ${server.info.uri}`)

--- a/packages/coordinator/src/server.ts
+++ b/packages/coordinator/src/server.ts
@@ -62,8 +62,7 @@ const configureLogging = async (server: Hapi.Server) => {
     }),
     // Redact Authorization headers, see https://getpino.io/#/docs/redaction
     redact: ["req.headers.authorization"],
-    wrapSerializers: false,
-    mergeHapiLogData: true
+    wrapSerializers: false
   })
 }
 

--- a/packages/coordinator/src/server.ts
+++ b/packages/coordinator/src/server.ts
@@ -32,6 +32,12 @@ export const createServer = ({collectLogs}: {collectLogs?: boolean}): Hapi.Serve
 
   server.route(routes)
 
+  server.ext([
+    {type: "onRequest", method: rejectInvalidProdHeaders},
+    {type: "onPreResponse", method: reformatUserErrorsToFhir},
+    {type: "onPreResponse", method: switchContentTypeForSmokeTest}
+  ])
+
   return server
 }
 
@@ -64,12 +70,6 @@ const configureLogging = async (server: Hapi.Server) => {
 export const init = async (): Promise<void> => {
   const server = createServer({})
   await configureLogging(server)
-  // add server extensions after configuring logging so they have access to the logger object
-  server.ext([
-    {type: "onRequest", method: rejectInvalidProdHeaders},
-    {type: "onPreResponse", method: reformatUserErrorsToFhir},
-    {type: "onPreResponse", method: switchContentTypeForSmokeTest}
-  ])
   await server.start()
   server.log("info", `Server running on ${server.info.uri}`)
 }

--- a/packages/coordinator/src/server.ts
+++ b/packages/coordinator/src/server.ts
@@ -32,12 +32,6 @@ export const createServer = ({collectLogs}: {collectLogs?: boolean}): Hapi.Serve
 
   server.route(routes)
 
-  server.ext([
-    {type: "onRequest", method: rejectInvalidProdHeaders},
-    {type: "onPreResponse", method: reformatUserErrorsToFhir},
-    {type: "onPreResponse", method: switchContentTypeForSmokeTest}
-  ])
-
   return server
 }
 
@@ -69,6 +63,12 @@ const configureLogging = async (server: Hapi.Server) => {
 export const init = async (): Promise<void> => {
   const server = createServer({})
   await configureLogging(server)
+  // add server extensions after configuring logging so they have access to the logger object
+  server.ext([
+    {type: "onRequest", method: rejectInvalidProdHeaders},
+    {type: "onPreResponse", method: reformatUserErrorsToFhir},
+    {type: "onPreResponse", method: switchContentTypeForSmokeTest}
+  ])
   await server.start()
   server.log("info", `Server running on ${server.info.uri}`)
 }

--- a/packages/coordinator/src/utils/server-extensions.ts
+++ b/packages/coordinator/src/utils/server-extensions.ts
@@ -92,7 +92,6 @@ export const rejectInvalidProdHeaders: Hapi.Lifecycle.Method = (
   request: Hapi.Request, responseToolkit: Hapi.ResponseToolkit
 ) => {
   const logPayload = isEpsHostedContainer()
-  const logger = request.logger
   if (isProd()) {
     const listOfInvalidHeaders = Object.keys(request.headers).filter(
       requestHeader => invalidProdHeaders.includes(requestHeader as RequestHeaders)
@@ -103,10 +102,12 @@ export const rejectInvalidProdHeaders: Hapi.Lifecycle.Method = (
       } had invalid header(s): ${
         listOfInvalidHeaders
       }`
-      logger.warn({
+      request.log("error", {
+        msg: "invalid headers",
         payload: getPayload(request, logPayload),
         errorMessage
-      }, "invalid headers")
+      })
+
       const issue = validationErrors.invalidHeaderOperationOutcome(listOfInvalidHeaders)
       return responseToolkit
         .response(fhir.createOperationOutcome([issue]))

--- a/packages/coordinator/src/utils/server-extensions.ts
+++ b/packages/coordinator/src/utils/server-extensions.ts
@@ -6,6 +6,25 @@ import {RequestHeaders} from "./headers"
 import {isProd} from "./environment"
 import {isEpsHostedContainer} from "./feature-flags"
 
+export const fatalResponse = {
+  resourceType: "OperationOutcome",
+  issue: [
+    {
+      severity: "fatal",
+      code: "exception",
+      details: {
+        coding: [
+          {
+            system: "https://fhir.nhs.uk/CodeSystem/http-error-codes",
+            code: "SERVER_ERROR",
+            display: "500: The Server has encountered an error processing the request."
+          }
+        ]
+      }
+    }
+  ]
+}
+
 export function reformatUserErrorsToFhir(
   request: Hapi.Request, responseToolkit: Hapi.ResponseToolkit
 ): Hapi.ResponseObject | symbol {
@@ -30,6 +49,9 @@ export function reformatUserErrorsToFhir(
       payload: getPayload(request, logPayload),
       response
     }, "Boom")
+    return responseToolkit.response(
+      fatalResponse
+    ).code(500).type(ContentTypes.FHIR)
   } else {
     if (response.statusCode >= 400) {
     // we DO log response here as we are sending back the same response

--- a/packages/coordinator/src/utils/server-extensions.ts
+++ b/packages/coordinator/src/utils/server-extensions.ts
@@ -44,10 +44,10 @@ export function reformatUserErrorsToFhir(
       processingErrors.toOperationOutcomeFatal(response)
     ).code(400).type(ContentTypes.FHIR)
   } else if (response instanceof Boom) {
-    // we DO log response here as we are sending back the same response
+    // we log the original response here but we send back a different response
     logger.error({
       payload: getPayload(request, logPayload),
-      response
+      originalResponse: response
     }, "Boom")
     return responseToolkit.response(
       fatalResponse

--- a/packages/coordinator/tests/app.test.ts
+++ b/packages/coordinator/tests/app.test.ts
@@ -3,7 +3,7 @@ import * as HapiShot from "@hapi/shot"
 import * as Headers from "../src/utils/headers"
 import {RequestHeaders} from "../src/utils/headers"
 import {isProd} from "../src/utils/environment"
-import {InvalidValueError} from "../../models/errors/processing-errors"
+import {InconsistentValuesError, InvalidValueError} from "../../models/errors/processing-errors"
 import {ContentTypes} from "../src/routes/util"
 import {
   invalidProdHeaders,
@@ -20,6 +20,7 @@ jest.mock("../src/utils/environment", () => ({
 const newIsProd = isProd as jest.MockedFunction<typeof isProd>
 
 describe("rejectInvalidProdHeaders extension", () => {
+  process.env.MTLS_SPINE_CLIENT = "false"
   const server = Hapi.server()
   server.route({
     method: "GET",
@@ -89,6 +90,7 @@ describe("rejectInvalidProdHeaders extension", () => {
 })
 
 describe("reformatUserErrorsToFhir extension", () => {
+  process.env.MTLS_SPINE_CLIENT = "false"
   const server = Hapi.server()
   const successRoute: Hapi.ServerRoute = {
     method: "GET",
@@ -114,7 +116,6 @@ describe("reformatUserErrorsToFhir extension", () => {
     }
   }
   server.route([successRoute, processingErrorRoute, otherErrorRoute])
-  server.ext("onPreResponse", reformatUserErrorsToFhir)
 
   beforeAll(async () => {
     await HapiPino.register(server, {
@@ -134,6 +135,7 @@ describe("reformatUserErrorsToFhir extension", () => {
       },
       wrapSerializers: false
     })
+    server.ext("onPreResponse", reformatUserErrorsToFhir)
   })
 
   test("formats processing errors", async () => {
@@ -157,6 +159,7 @@ describe("reformatUserErrorsToFhir extension", () => {
 })
 
 describe("switchContentTypeForSmokeTest extension", () => {
+  process.env.MTLS_SPINE_CLIENT = "false"
   const server = Hapi.server()
   const fhirRoute: Hapi.ServerRoute = {
     method: "GET",
@@ -195,4 +198,212 @@ describe("switchContentTypeForSmokeTest extension", () => {
     expect(fhirResponse.headers["content-type"]).toContain(ContentTypes.FHIR)
     expect(xmlResponse.headers["content-type"]).toContain(ContentTypes.XML)
   })
+})
+
+describe("logs payload on proxygen deployed", () => {
+  process.env.MTLS_SPINE_CLIENT = "true"
+  const server = Hapi.server()
+  const successRoute: Hapi.ServerRoute = {
+    method: "GET",
+    path: "/test",
+    handler: (_, responseToolkit) => {
+      return responseToolkit.response("success")
+    }
+  }
+  const processingErrorRoute: Hapi.ServerRoute = {
+    method: "POST",
+    path: "/processing-error",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handler: (_, h) => {
+      throw new InvalidValueError("")
+    }
+  }
+  const inconsistentValueErrorRoute: Hapi.ServerRoute = {
+    method: "POST",
+    path: "/inconsistentValue-error",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handler: (_, h) => {
+      throw new InconsistentValuesError("")
+    }
+  }
+  const warningRoute: Hapi.ServerRoute = {
+    method: "POST",
+    path: "/warning",
+    handler: (_, responseToolkit) => {
+      return responseToolkit.response("warning").code(400)
+    }
+  }
+  const otherErrorRoute: Hapi.ServerRoute = {
+    method: "POST",
+    path: "/other-error",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handler: (_, h) => {
+      throw new Error("")
+    }
+  }
+  server.route([
+    successRoute,
+    processingErrorRoute,
+    otherErrorRoute,
+    inconsistentValueErrorRoute,
+    warningRoute
+  ])
+
+  const loggerSpy = jest.fn()
+
+  server.events.on({name: "request", channels: "app"}, loggerSpy)
+
+  beforeAll(async () => {
+    await HapiPino.register(server, {
+      transport: {
+        target: "pino-pretty",
+        options: {
+          colorize: true,
+          minimumLevel: "info",
+          levelFirst: true,
+          messageFormat: true,
+          timestampKey: "time",
+          translateTime: true,
+          singleLine: false,
+          mkdir: true,
+          append: true
+        }
+      },
+      wrapSerializers: false,
+      mergeHapiLogData: true
+    })
+    server.ext("onPreResponse", reformatUserErrorsToFhir)
+  })
+
+  beforeEach(() => {
+    loggerSpy.mockReset()
+  })
+
+  test("logs FhirMessageProcessingError", async () => {
+    const response = await server.inject({
+      url: "/processing-error",
+      payload: {foo: "bar"},
+      method: "POST"
+    })
+    expect(response.payload).toContain("OperationOutcome")
+    expect(response.statusCode).toBe(400)
+    expect(response.headers["content-type"]).toBe(ContentTypes.FHIR)
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        "channel": "app",
+        "data": {
+          "msg": "FhirMessageProcessingError",
+          "payload": {
+            "foo": "bar"
+          }
+        },
+        "request": expect.anything(),
+        "tags": [
+          "info"
+        ],
+        "timestamp": expect.anything()
+      },
+      {"info": true}
+    )
+  })
+
+  test("logs InconsistentValuesError", async () => {
+    const response = await server.inject({
+      url: "/inconsistentValue-error",
+      payload: {foo: "bar"},
+      method: "POST"
+    })
+    expect(response.payload).toContain("OperationOutcome")
+    expect(response.statusCode).toBe(400)
+    expect(response.headers["content-type"]).toBe(ContentTypes.FHIR)
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        "channel": "app",
+        "data": {
+          "msg": "InconsistentValuesError",
+          "payload": {
+            "foo": "bar"
+          }
+        },
+        "request": expect.anything(),
+        "tags": [
+          "info"
+        ],
+        "timestamp": expect.anything()
+      },
+      {"info": true}
+    )
+  })
+
+  test("doesn't log on success", async () => {
+    const response = await server.inject({url: "/test"})
+    expect(response.payload).toBe("success")
+    expect(response.statusCode).toBe(200)
+    expect(loggerSpy).not.toHaveBeenCalled()
+  })
+
+  test("logs boom errors", async () => {
+    const response = await server.inject({
+      url: "/other-error",
+      method: "POST",
+      payload: {
+        "foo": "bar"
+      }
+    })
+    expect(response.payload).not.toContain("OperationOutcome")
+    expect(response.statusCode).toBe(500)
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        "channel": "app",
+        "data": {
+          "msg": "Boom",
+          "payload": {
+            "foo": "bar"
+          },
+          "response": expect.anything()
+        },
+        "request": expect.anything(),
+        "tags": [
+          "error"
+        ],
+        "timestamp": expect.anything()
+      },
+      {"error": true}
+    )
+  })
+
+  test("logs 400 errors", async () => {
+    const response = await server.inject({
+      url: "/warning",
+      method: "POST",
+      payload: {
+        "foo": "bar"
+      }
+    })
+    expect(response.payload).not.toContain("OperationOutcome")
+    expect(response.statusCode).toBe(400)
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        "channel": "app",
+        "data": {
+          "msg": "ErrorOrWarningResponse",
+          "payload": {
+            "foo": "bar"
+          },
+          "response": expect.anything()
+        },
+        "request": expect.anything(),
+        "tags": [
+          "info"
+        ],
+        "timestamp": expect.anything()
+      },
+      {"info": true}
+    )
+  })
+
 })

--- a/packages/coordinator/tests/app.test.ts
+++ b/packages/coordinator/tests/app.test.ts
@@ -116,6 +116,26 @@ describe("reformatUserErrorsToFhir extension", () => {
   server.route([successRoute, processingErrorRoute, otherErrorRoute])
   server.ext("onPreResponse", reformatUserErrorsToFhir)
 
+  beforeAll(async () => {
+    await HapiPino.register(server, {
+      transport: {
+        target: "pino-pretty",
+        options: {
+          colorize: true,
+          minimumLevel: "info",
+          levelFirst: true,
+          messageFormat: true,
+          timestampKey: "time",
+          translateTime: true,
+          singleLine: false,
+          mkdir: true,
+          append: true
+        }
+      },
+      wrapSerializers: false
+    })
+  })
+
   test("formats processing errors", async () => {
     const response = await server.inject({url: "/processing-error"})
     expect(response.payload).toContain("OperationOutcome")

--- a/packages/coordinator/tests/logging/incomingPayloads.spec.ts
+++ b/packages/coordinator/tests/logging/incomingPayloads.spec.ts
@@ -31,7 +31,7 @@ describe.each(TestResources.specification)(
     let logs: Array<Hapi.RequestLog>
 
     beforeAll(async () => {
-      server = createServer({collectLogs: true})
+      server = createServer({collectLogs: true}, 9001)
       await configureLogging(server)
       await server.start()
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- log payload on error or warning response
- use a different port for hapi tests to avoid clashes