### PR TITLE
Fix: [AEA-5132] - reject multiple certificates

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -20,6 +20,9 @@ const token = await getAuthToken()
 throw new Error\(`Cannot retrieve auth token: \${requestUrl} returned \${response.data}`\)
 throw `Could not retrieve token: \${result.data}
 
+# ignore adding begin and end certificate in verification code
+^([a-f0-9]{40}:)?packages\/coordinator\/src\/services\/verification\/common\.ts:.*BEGIN CERTIFICATE.*
+^([a-f0-9]{40}:)?packages\/coordinator\/src\/services\/verification\/common\.ts:.*END CERTIFICATE.*
 # ignore dummy account id in cdk.json
  "accountId": "766544332211"
 

--- a/packages/coordinator/src/services/verification/certificate-revocation/verify.ts
+++ b/packages/coordinator/src/services/verification/certificate-revocation/verify.ts
@@ -1,4 +1,4 @@
-import pino from "pino"
+import pino, {Logger} from "pino"
 import {X509} from "jsrsasign"
 import {hl7V3} from "@models"
 import {CRLReasonCode} from "./crl-reason-code"
@@ -82,8 +82,8 @@ type CertData = {
   serialNumber: string
 }
 
-const parseCertificateFromPrescription = (parentPrescription: hl7V3.ParentPrescription): CertData => {
-  const certificate = getCertificateFromPrescription(parentPrescription)
+const parseCertificateFromPrescription = (parentPrescription: hl7V3.ParentPrescription, logger: Logger): CertData => {
+  const certificate = getCertificateFromPrescription(parentPrescription, logger)
   const serialNumber = getX509SerialNumber(certificate)
   return {certificate, serialNumber}
 }
@@ -123,7 +123,7 @@ const isSignatureCertificateAuthorityValid = async (
   parentPrescription: hl7V3.ParentPrescription,
   logger: pino.Logger
 ): Promise<boolean> => {
-  const {certificate, serialNumber} = parseCertificateFromPrescription(parentPrescription)
+  const {certificate, serialNumber} = parseCertificateFromPrescription(parentPrescription, logger)
   const subCaCert = getSubCaCert(certificate, serialNumber, logger)
   if (!subCaCert) {
     logger.error(
@@ -149,7 +149,7 @@ const isSignatureCertificateValid = async (
   parentPrescription: hl7V3.ParentPrescription,
   logger: pino.Logger
 ): Promise<boolean> => {
-  const {certificate, serialNumber} = parseCertificateFromPrescription(parentPrescription)
+  const {certificate, serialNumber} = parseCertificateFromPrescription(parentPrescription, logger)
   const prescriptionSignedDate = getPrescriptionSignatureDate(parentPrescription)
   const prescriptionId = getPrescriptionId(parentPrescription)
 

--- a/packages/coordinator/src/services/verification/common.ts
+++ b/packages/coordinator/src/services/verification/common.ts
@@ -1,5 +1,6 @@
 import {ElementCompact} from "xml-js"
 import {hl7V3} from "@models"
+import crypto from "crypto"
 
 export const getCertificateTextFromPrescription = (prescription: hl7V3.ParentPrescription): string => {
   const signatureRoot = extractSignatureRootFromParentPrescription(prescription)
@@ -17,4 +18,10 @@ export function extractSignatureRootFromParentPrescription(
 export function extractSignatureDateTimeStamp(parentPrescriptions: hl7V3.ParentPrescription): hl7V3.Timestamp {
   const author = parentPrescriptions.pertinentInformation1.pertinentPrescription.author
   return author.time
+}
+
+export function getCertificateFromPrescriptionCrypto(signatureRoot: ElementCompact): crypto.X509Certificate {
+  const x509CertificateText: string = signatureRoot.Signature.KeyInfo.X509Data.X509Certificate._text
+  const x509Certificate = `-----BEGIN CERTIFICATE-----\n${x509CertificateText.trim()}\n-----END CERTIFICATE-----`
+  return new crypto.X509Certificate(x509Certificate)
 }

--- a/packages/coordinator/src/services/verification/signature-verification.ts
+++ b/packages/coordinator/src/services/verification/signature-verification.ts
@@ -23,7 +23,7 @@ export const verifyPrescriptionSignature = async (
   }
 
   const hasSingleCertificate = verifySignatureHasSingleCertificate(signatureRoot)
-  if (hasSingleCertificate) {
+  if (!hasSingleCertificate) {
     return ["Multiple certificates detected"]
   }
 
@@ -91,7 +91,7 @@ function verifySignatureHasCorrectFormat(signatureRoot: ElementCompact): boolean
 function verifySignatureHasSingleCertificate(signatureRoot: ElementCompact): boolean {
   const signature = signatureRoot?.Signature
   const x509Certificate: string = signature?.KeyInfo?.X509Data?.X509Certificate?._text || ""
-  return (x509Certificate.includes("BEGIN CERTIFICATE") || x509Certificate.includes("END CERTIFICATE"))
+  return (!x509Certificate.includes("BEGIN CERTIFICATE") && !x509Certificate.includes("END CERTIFICATE"))
 }
 
 async function verifySignatureDigestMatchesPrescription(

--- a/packages/coordinator/src/services/verification/signature-verification.ts
+++ b/packages/coordinator/src/services/verification/signature-verification.ts
@@ -10,6 +10,7 @@ import {isSignatureCertificateAuthorityValid, isSignatureCertificateValid} from 
 import {convertHL7V3DateTimeToIsoDateTimeString, isDateInRange} from "../translation/common/dateTime"
 import {HashingAlgorithm, getHashingAlgorithmFromSignatureRoot} from "../translation/common/hashingAlgorithm"
 import {getSubCaCerts} from "./certificate-revocation/utils"
+import {getCertificateFromPrescriptionCrypto} from "./common"
 
 export const verifyPrescriptionSignature = async (
   parentPrescription: hl7V3.ParentPrescription,
@@ -19,6 +20,11 @@ export const verifyPrescriptionSignature = async (
   const validSignatureFormat = verifySignatureHasCorrectFormat(signatureRoot)
   if (!validSignatureFormat) {
     return ["Invalid signature format"]
+  }
+
+  const hasSingleCertificate = verifySignatureHasSingleCertificate(signatureRoot)
+  if (hasSingleCertificate) {
+    return ["Multiple certificates detected"]
   }
 
   let certificate: crypto.X509Certificate
@@ -82,6 +88,12 @@ function verifySignatureHasCorrectFormat(signatureRoot: ElementCompact): boolean
   return isTruthy(signedInfo) && isTruthy(signatureValue) && isTruthy(x509Certificate)
 }
 
+function verifySignatureHasSingleCertificate(signatureRoot: ElementCompact): boolean {
+  const signature = signatureRoot?.Signature
+  const x509Certificate: string = signature?.KeyInfo?.X509Data?.X509Certificate?._text || ""
+  return (x509Certificate.includes("BEGIN CERTIFICATE") || x509Certificate.includes("END CERTIFICATE"))
+}
+
 async function verifySignatureDigestMatchesPrescription(
   parentPrescription: hl7V3.ParentPrescription,
   signatureRoot: ElementCompact
@@ -106,12 +118,6 @@ function verifyCertificateValidWhenSigned(signatureDate: Date, certificate: cryp
   const certificateStartDate = new Date(certificate.validFrom)
   const certificateEndDate = new Date(certificate.validTo)
   return isDateInRange(signatureDate, certificateStartDate, certificateEndDate)
-}
-
-function getCertificateFromPrescriptionCrypto(signatureRoot: ElementCompact): crypto.X509Certificate {
-  const x509CertificateText: string = signatureRoot.Signature.KeyInfo.X509Data.X509Certificate._text
-  const x509Certificate = `-----BEGIN CERTIFICATE-----\n${x509CertificateText.trim()}\n-----END CERTIFICATE-----`
-  return new crypto.X509Certificate(x509Certificate)
 }
 
 function extractSignatureDateTimeStamp(parentPrescriptions: hl7V3.ParentPrescription): Date {

--- a/packages/coordinator/tests/services/verification/signature-verification.spec.ts
+++ b/packages/coordinator/tests/services/verification/signature-verification.spec.ts
@@ -50,6 +50,18 @@ describe("verifyPrescriptionSignature", () => {
       const result = await verifyPrescriptionSignature(clonePrescription, logger)
       expect(result).toContain("Invalid signature format")
     })
+
+    test("fails if prescriptions signature has multiple X509Cert", async () => {
+      const clonePrescription = clone(validSignature)
+      const signatureRoot = extractSignatureRootFromParentPrescription(clonePrescription)
+      const currentSignature = signatureRoot.Signature.KeyInfo.X509Data.X509Certificate._text
+      signatureRoot.Signature.KeyInfo.X509Data.X509Certificate._text =
+        currentSignature +
+        "\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n" +
+        currentSignature
+      const result = await verifyPrescriptionSignature(clonePrescription, logger)
+      expect(result).toContain("Multiple certificates detected")
+    })
   })
 
   describe("Invalid certificate", () => {


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- do not allow prescriptions with multiple certificates to be released
- only use crypto to extract certificate