### PR TITLE
Fix: [AEA-5172] - always use default asid/party key in PTL

### DIFF
--- a/packages/coordinator/src/utils/headers.ts
+++ b/packages/coordinator/src/utils/headers.ts
@@ -67,11 +67,11 @@ export function getPartyKey(headers: Hapi.Utils.Dictionary<string>): string {
   if (isSandbox()) {
     return DEFAULT_SANDBOX_PARTY_KEY
   }
-  if (headers[RequestHeaders.PARTY_KEY] !== undefined) {
-    return headers[RequestHeaders.PARTY_KEY]
-  }
   if (isEpsHostedContainer() && enableDefaultAsidPartyKey()) {
     return DEFAULT_PTL_PARTY_KEY
+  }
+  if (headers[RequestHeaders.PARTY_KEY] !== undefined) {
+    return headers[RequestHeaders.PARTY_KEY]
   }
 
   throw new Error("Could not get party key")

--- a/packages/coordinator/src/utils/headers.ts
+++ b/packages/coordinator/src/utils/headers.ts
@@ -53,11 +53,11 @@ export function getAsid(headers: Hapi.Utils.Dictionary<string>): string {
   if (isSandbox()) {
     return DEFAULT_SANDBOX_ASID
   }
-  if (headers[RequestHeaders.ASID] !== undefined) {
-    return headers[RequestHeaders.ASID]
-  }
   if (isEpsHostedContainer() && enableDefaultAsidPartyKey()) {
     return DEFAULT_PTL_ASID
+  }
+  if (headers[RequestHeaders.ASID] !== undefined) {
+    return headers[RequestHeaders.ASID]
   }
 
   throw new Error("Could not get ASID")


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- always use default asid/party key in PTL