### PR TITLE
Fix: [AEA-0000] - use fixed polling delay and send claims validator logs to splunk

### DIFF
--- a/packages/cdk/resources/LogGroups.ts
+++ b/packages/cdk/resources/LogGroups.ts
@@ -122,7 +122,7 @@ export class LogGroups extends Construct {
     new CfnSubscriptionFilter(this, "ClaimsValidatorSplunkSubscriptionFilter", {
       destinationArn: props.splunkDeliveryStream.streamArn,
       filterPattern: "",
-      logGroupName: validatorLogGroup.logGroupName,
+      logGroupName: claimsValidatorLogGroup.logGroupName,
       roleArn: props.splunkSubscriptionFilterRole.roleArn
     })
 

--- a/packages/coordinator/src/services/communication/common.ts
+++ b/packages/coordinator/src/services/communication/common.ts
@@ -14,7 +14,7 @@ import axiosRetry from "axios-retry"
 // set polling timeout to be 25 seconds
 const pollingTimeout = 25000
 // set default polling delay to be 5 seconds if it is not in response
-const defaultPollingDelay = 5000
+const defaultPollingDelay = 5
 
 export const notSupportedOperationOutcome: fhir.OperationOutcome = {
   resourceType: "OperationOutcome",
@@ -223,9 +223,9 @@ export abstract class BaseSpineClient implements SpineClient {
         }
       }
       const retryDelayString = result.headers["retry-after"] ?? defaultPollingDelay
-      let retryDelay = Number(retryDelayString)
+      let retryDelay = Number(retryDelayString)*1000
       if (isNaN(retryDelay)) {
-        retryDelay = defaultPollingDelay
+        retryDelay = defaultPollingDelay*1000
       }
       totalPollingTime = totalPollingTime + retryDelay
       logger.info("Received pollable response")

--- a/packages/coordinator/src/services/communication/common.ts
+++ b/packages/coordinator/src/services/communication/common.ts
@@ -13,8 +13,9 @@ import axiosRetry from "axios-retry"
 
 // set polling timeout to be 25 seconds
 export const pollingTimeout = 25000
-// set default polling delay to be 5 seconds if it is not in response
-export const defaultPollingDelay = 1000
+// set delay between polling to be 5 seconds
+export const defaultPollingDelay = 5000
+// set initial polling delay to be 0.5 seconds
 export const initialPollingDelay = 500
 
 export const notSupportedOperationOutcome: fhir.OperationOutcome = {

--- a/packages/coordinator/src/services/communication/common.ts
+++ b/packages/coordinator/src/services/communication/common.ts
@@ -12,10 +12,10 @@ import {SpineClient} from "./spine-client"
 import axiosRetry from "axios-retry"
 
 // set polling timeout to be 25 seconds
-const pollingTimeout = 25000
+export const pollingTimeout = 25000
 // set default polling delay to be 5 seconds if it is not in response
-const defaultPollingDelay = 1000
-const initialPollingDelay = 500
+export const defaultPollingDelay = 1000
+export const initialPollingDelay = 500
 
 export const notSupportedOperationOutcome: fhir.OperationOutcome = {
   resourceType: "OperationOutcome",

--- a/packages/coordinator/tests/services/communication/spine-communication.spec.ts
+++ b/packages/coordinator/tests/services/communication/spine-communication.spec.ts
@@ -44,7 +44,7 @@ describe.each([
   test("Successful send response returns non pollable result when spine returns pollable", async () => {
     mock.onPost().reply(202, 'statusText: "OK"', {
       "content-location": "/_poll/test-content-location",
-      "retry-after": 100
+      "retry-after": 1
     })
     mock.onGet().reply(200, "foo")
 
@@ -57,12 +57,12 @@ describe.each([
   test("Successful send response calls polling twice when poll result returned first", async () => {
     mock.onPost().reply(202, 'statusText: "OK"', {
       "content-location": "/_poll/test-content-location",
-      "retry-after": 100
+      "retry-after": 1
     })
     mock
       .onGet()
       .replyOnce(202, "foo", {
-        "retry-after": 100
+        "retry-after": 1
       })
       .onGet()
       .replyOnce(200, "foo")
@@ -74,17 +74,17 @@ describe.each([
     expect(spineResponse.statusCode).toBe(200)
     expect(spine.isPollable(spineResponse)).toBe(false)
 
-    const firstMessage = "First call, delay 100 milliseconds before checking result"
-    const secondMessage = "Waiting 100 milliseconds before polling again. Attempt 1"
+    const firstMessage = "First call, delay 1000 milliseconds before checking result"
+    const secondMessage = "Waiting 1000 milliseconds before polling again. Attempt 1"
     expect(loggerSpy).toHaveBeenCalledWith({
-      retryDelay: 100,
+      retryDelay: 1000,
       attempt: 0,
-      totalPollingTime: 100
+      totalPollingTime: 1000
     }, firstMessage)
     expect(loggerSpy).toHaveBeenCalledWith({
-      retryDelay: 100,
+      retryDelay: 1000,
       attempt: 1,
-      totalPollingTime: 200
+      totalPollingTime: 2000
     },
     secondMessage)
 
@@ -95,12 +95,12 @@ describe.each([
   test("Successful send response calls polling twice when poll returns empty 200 response", async () => {
     mock.onPost().reply(202, 'statusText: "OK"', {
       "content-location": "/_poll/test-content-location",
-      "retry-after": 100
+      "retry-after": 1
     })
     mock
       .onGet()
       .replyOnce(200, "", {
-        "retry-after": 100
+        "retry-after": 1
       })
       .onGet()
       .replyOnce(200, "foo")
@@ -113,18 +113,18 @@ describe.each([
     expect((spineResponse as spine.SpineDirectResponse<string>).body).toEqual("foo")
     expect(spine.isPollable(spineResponse)).toBe(false)
 
-    const firstMessage = "First call, delay 100 milliseconds before checking result"
-    const secondMessage = "Waiting 100 milliseconds before polling again. Attempt 1"
+    const firstMessage = "First call, delay 1000 milliseconds before checking result"
+    const secondMessage = "Waiting 1000 milliseconds before polling again. Attempt 1"
     expect(loggerSpy).toHaveBeenCalledWith("Empty body returned from spine - treating as 202 response")
     expect(loggerSpy).toHaveBeenCalledWith({
-      retryDelay: 100,
+      retryDelay: 1000,
       attempt: 0,
-      totalPollingTime: 100
+      totalPollingTime: 1000
     }, firstMessage)
     expect(loggerSpy).toHaveBeenCalledWith({
-      retryDelay: 100,
+      retryDelay: 1000,
       attempt: 1,
-      totalPollingTime: 200
+      totalPollingTime: 2000
     },
     secondMessage)
 
@@ -325,7 +325,7 @@ describe.each([
       .networkErrorOnce()
     mock.onPost().reply(202, 'statusText: "OK"', {
       "content-location": "/_poll/test-content-location",
-      "retry-after": 100
+      "retry-after": 1
     })
     mock.onGet().reply(200, "foo")
     const loggerWarnSpy = jest.spyOn(logger, "warn")


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- send claims validator logs to splunk
- correct delay between polling