### PR TITLE
Fix: [AEA-5392] - changing so you cant have null as identifier

### DIFF
--- a/packages/coordinator/src/services/translation/response/practitioner.ts
+++ b/packages/coordinator/src/services/translation/response/practitioner.ts
@@ -1,21 +1,24 @@
-import {convertName, generateResourceId} from "./common"
-import {fhir, hl7V3} from "@models"
-import {createPractitionerOrRoleIdentifier} from "./identifiers"
+import { convertName, generateResourceId } from "./common"
+import { fhir, hl7V3 } from "@models"
+import { createPractitionerOrRoleIdentifier } from "./identifiers"
 
 export function createPractitioner(agentPerson: hl7V3.AgentPerson): fhir.Practitioner {
-  return {
+  const identifier = createPractitionerIdentifier(agentPerson.agentPerson.id._attributes.extension);
+  const practitioner: fhir.Practitioner = {
     resourceType: "Practitioner",
     id: generateResourceId(),
-    identifier: createPractitionerIdentifier(agentPerson.agentPerson.id._attributes.extension),
     name: convertName(agentPerson.agentPerson.name)
   }
+  if (identifier) {
+    practitioner.identifier = identifier;
+  }
+  return practitioner;
 }
 
-export function createPractitionerIdentifier(userId: string): Array<fhir.Identifier> {
+export function createPractitionerIdentifier(userId: string): Array<fhir.Identifier> | undefined {
   const identifier = createPractitionerOrRoleIdentifier(userId)
   if (identifier.system !== "https://fhir.hl7.org.uk/Id/nhsbsa-spurious-code") {
     return [identifier]
   }
-
-  return null
+  return undefined
 }


### PR DESCRIPTION
## Summary

Fixing it so you cant have null as an identifier code which is against FHIR schema

- Routine Change
