### PR TITLE
Docs: [AEA-5504] - Remove reference to GP2GP from EPS FHIR API OASes (Prescribing and Dispensing)

### DIFF
--- a/packages/specification/electronic-prescription-service-api.template.yaml
+++ b/packages/specification/electronic-prescription-service-api.template.yaml
@@ -51,7 +51,6 @@ info:
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.
     * [Digital Signature Service](https://digital.nhs.uk/developer/api-catalogue/signing-service) - use the signing service API to create signatures for prescriptions. The signing service is only used for EPS.
     * [Role-Based Access Controls (RBAC)](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/national-rbac-for-developers) - RBAC rules are stored in the National RBAC Database (NRD) and are used to limit what prescribers can and cannot do.
-    * [GP2GP](https://digital.nhs.uk/services/gp2gp) - use the GP2GP service to transfer patient details, including nominated dispensers, between GPs.
     * [Message Exchange for Social Care and Health (MESH)](https://digital.nhs.uk/developer/api-catalogue/message-exchange-for-social-care-and-health-api) - Use MESH to deliver and receive cancel responses.
     * [Prescription Tracker](https://developer.nhs.uk/apis/eps-tracker) - use this if you want a read-only interface to get information about a patient's prescriptions.
     * [Real-Time Exemption Checking](https://nhsconnect.github.io/prescription-exemptions/) - dispensing systems must use the Real-Time Exemption Checking service to prevent prescriptions fraud and enable effective processing of charge exemptions.

--- a/packages/specification/electronic-prescription-service-api.yaml
+++ b/packages/specification/electronic-prescription-service-api.yaml
@@ -51,7 +51,6 @@ info:
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.
     * [Digital Signature Service](https://digital.nhs.uk/developer/api-catalogue/signing-service) - use the signing service API to create signatures for prescriptions. The signing service is only used for EPS.
     * [Role-Based Access Controls (RBAC)](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/national-rbac-for-developers) - RBAC rules are stored in the National RBAC Database (NRD) and are used to limit what prescribers can and cannot do.
-    * [GP2GP](https://digital.nhs.uk/services/gp2gp) - use the GP2GP service to transfer patient details, including nominated dispensers, between GPs.
     * [Message Exchange for Social Care and Health (MESH)](https://digital.nhs.uk/developer/api-catalogue/message-exchange-for-social-care-and-health-api) - Use MESH to deliver and receive cancel responses.
     * [Prescription Tracker](https://developer.nhs.uk/apis/eps-tracker) - use this if you want a read-only interface to get information about a patient's prescriptions.
     * [Real-Time Exemption Checking](https://nhsconnect.github.io/prescription-exemptions/) - dispensing systems must use the Real-Time Exemption Checking service to prevent prescriptions fraud and enable effective processing of charge exemptions.

--- a/packages/specification/fhir-dispensing.yaml
+++ b/packages/specification/fhir-dispensing.yaml
@@ -40,7 +40,6 @@ info:
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.
     * [Digital Signature Service](https://digital.nhs.uk/developer/api-catalogue/signing-service) - use the signing service API to create signatures for prescriptions. The signing service is only used for EPS.
     * [Role-Based Access Controls (RBAC)](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/national-rbac-for-developers) - RBAC rules are stored in the National RBAC Database (NRD) and are used to limit what prescribers can and cannot do.
-    * [GP2GP](https://digital.nhs.uk/services/gp2gp) - use the GP2GP service to transfer patient details, including nominated dispensers, between GPs.
     * [Message Exchange for Social Care and Health (MESH)](https://digital.nhs.uk/developer/api-catalogue/message-exchange-for-social-care-and-health-api) - Use MESH to deliver and receive cancel responses.
     * [Prescription Tracker](https://developer.nhs.uk/apis/eps-tracker) - use this if you want a read-only interface to get information about a patient's prescriptions.
     * [Real-Time Exemption Checking](https://nhsconnect.github.io/prescription-exemptions/) - dispensing systems must use the Real-Time Exemption Checking service to prevent prescriptions fraud and enable effective processing of charge exemptions.

--- a/packages/specification/fhir-prescribing.yaml
+++ b/packages/specification/fhir-prescribing.yaml
@@ -36,7 +36,6 @@ info:
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.
     * [Digital Signature Service](https://digital.nhs.uk/developer/api-catalogue/signing-service) - use the signing service API to create signatures for prescriptions. The signing service is only used for EPS.
     * [Role-Based Access Controls (RBAC)](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/national-rbac-for-developers) - RBAC rules are stored in the National RBAC Database (NRD) and are used to limit what prescribers can and cannot do.
-    * [GP2GP](https://digital.nhs.uk/services/gp2gp) - use the GP2GP service to transfer patient details, including nominated dispensers, between GPs.
     * [Message Exchange for Social Care and Health (MESH)](https://digital.nhs.uk/developer/api-catalogue/message-exchange-for-social-care-and-health-api) - Use MESH to deliver and receive cancel responses.
     * [Prescription Tracker](https://developer.nhs.uk/apis/eps-tracker) - use this if you want a read-only interface to get information about a patient's prescriptions.
     * [Real-Time Exemption Checking](https://nhsconnect.github.io/prescription-exemptions/) - dispensing systems must use the Real-Time Exemption Checking service to prevent prescriptions fraud and enable effective processing of charge exemptions.


### PR DESCRIPTION
## Summary

🎫 [AEA-5504](https://nhsd-jira.digital.nhs.uk/browse/AEA-5504) Remove reference to GP2GP from EPS FHIR API OASes (Prescribing and Dispensing)

- Routine Change

### Details

This pull request removes all references to GP2GP from the EPS FHIR API OAS pages.