### PR TITLE
Docs: [AEA-5748] - OAS - Medication request extension

### DIFF
--- a/packages/specification/schemas/components/_extensions/ControlledDrug.yaml
+++ b/packages/specification/schemas/components/_extensions/ControlledDrug.yaml
@@ -10,7 +10,7 @@ properties:
     type: array
     description: FHIR extension array.
     items:
-      oneOf:
+      anyOf:
         - type: object
           description: object containing the quantity in words
           properties:


### PR DESCRIPTION
## Summary

🎫 [AEA-5748](https://nhsd-jira.digital.nhs.uk/browse/AEA-5748) OAS - Medication request extension

- Routine Change

### Details

This pull request updates the `ControlledDrug` extension to allow both the `quantityWords` and `schedule` elements to be present together, in line with the Simplifier specification.