### PR TITLE
Docs: [AEA-5733] - OAS Update - Update the 'Status' so that suppliers are told to hardcode one status in the Dispense notification

### DIFF
--- a/packages/specification/schemas/components/MedicationDispense/MedicationDispense.yaml
+++ b/packages/specification/schemas/components/MedicationDispense/MedicationDispense.yaml
@@ -37,17 +37,9 @@ properties:
     type: string
     description: |
       The status of the individual medication item.
-      This will normally indicate whether the medication has been picked up or not.
-    enum:
-      - preparation
-      - in-progress
-      - cancelled
-      - on-hold
-      - completed
-      - entered-in-error
-      - stopped
-      - declined
-      - unknown
+      This field is hardcoded to 'in-progress' as other statuses are not used by the EPS FHIR API or Spine.
+    enum: [in-progress]
+    default: in-progress
   statusReasonCodeableConcept:
     type: object
     description: Where a medication item is not dispensed, the reason it was not dispensed.


### PR DESCRIPTION
## Summary

🎫 [AEA-5733](https://nhsd-jira.digital.nhs.uk/browse/AEA-5733) OAS Update - Update the 'Status' so that suppliers are told to hardcode one status in the Dispense notification

- Routine Change

### Details

This pull request updates the 'Status' field to ensure suppliers hardcode a single status in the Dispense notification.