### PR TITLE
Docs: [AEA-5111] - OAS Update - CIS2 advice to state authentication can use smartcard or modern alternatives

### DIFF
--- a/packages/specification/electronic-prescription-service-api.template.yaml
+++ b/packages/specification/electronic-prescription-service-api.template.yaml
@@ -45,7 +45,7 @@ info:
        
     ### Services
     These services must be used alongside EPS to create a functioning prescribing or dispensing system.
-    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard.
+    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard or a modern alternative.
     * [Directory of Services (DOS)](https://digital.nhs.uk/services/directory-of-services-dos) - prescribers must use the DOS to find dispensing sites for patients.
     * [Organisation Data Service (ODS)](https://digital.nhs.uk/developer/api-catalogue/organisation-data-service-fhir) - use this to access ODS codes for prescribing organisations.
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.

--- a/packages/specification/electronic-prescription-service-api.yaml
+++ b/packages/specification/electronic-prescription-service-api.yaml
@@ -45,7 +45,7 @@ info:
        
     ### Services
     These services must be used alongside EPS to create a functioning prescribing or dispensing system.
-    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard.
+    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard or a modern alternative.
     * [Directory of Services (DOS)](https://digital.nhs.uk/services/directory-of-services-dos) - prescribers must use the DOS to find dispensing sites for patients.
     * [Organisation Data Service (ODS)](https://digital.nhs.uk/developer/api-catalogue/organisation-data-service-fhir) - use this to access ODS codes for prescribing organisations.
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.

--- a/packages/specification/fhir-dispensing.yaml
+++ b/packages/specification/fhir-dispensing.yaml
@@ -34,7 +34,7 @@ info:
       
     ### Services
     These services must be used alongside EPS to create a functioning prescribing or dispensing system.
-    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard.
+    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard or a modern alternative.
     * [Directory of Services (DOS)](https://digital.nhs.uk/services/directory-of-services-dos) - prescribers must use the DOS to find dispensing sites for patients.
     * [Organisation Data Service (ODS)](https://digital.nhs.uk/developer/api-catalogue/organisation-data-service-fhir) - use this to access ODS codes for prescribing organisations.
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.

--- a/packages/specification/fhir-prescribing.yaml
+++ b/packages/specification/fhir-prescribing.yaml
@@ -30,7 +30,7 @@ info:
       
     ### Services
     These services must be used alongside EPS to create a functioning prescribing or dispensing system.
-    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard.
+    * [Care Identity Service 2 (CIS2)](https://digital.nhs.uk/services/identity-and-access-management/national-care-identity-service) - use this to authenticate prescribers with their smartcard or a modern alternative.
     * [Directory of Services (DOS)](https://digital.nhs.uk/services/directory-of-services-dos) - prescribers must use the DOS to find dispensing sites for patients.
     * [Organisation Data Service (ODS)](https://digital.nhs.uk/developer/api-catalogue/organisation-data-service-fhir) - use this to access ODS codes for prescribing organisations.
     * [Personal Demographics Service (PDS)](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - use PDS to synchronise a patient's demographic details including their name, date of birth and address.


### PR DESCRIPTION
## Summary

🎫 [AEA-5111](https://nhsd-jira.digital.nhs.uk/browse/AEA-5111) OAS Update - CIS2 advice to state authentication can use smartcard or modern alternatives

- Routine Change

### Details

This pull request updates the OAS with CIS2 guidance to clarify that authentication can be performed using a smartcard or modern alternatives.