### PR TITLE
Docs: [AEA-5040] - Release by id example is wrong for with another dispenser response

### DIFF
--- a/examples/spec/errors/release/with-another-dispenser-error.json
+++ b/examples/spec/errors/release/with-another-dispenser-error.json
@@ -1,8 +1,8 @@
 {
   "resourceType": "OperationOutcome",
   "meta": {
-    "lastUpdated": "2022-10-21T13:47:00+00:00"
-    },
+    "lastUpdated": "2025-02-14T11:30:29+00:00"
+  },
   "issue": [
     {
       "code": "business-rule",
@@ -15,8 +15,47 @@
             "display": "Prescription is with another dispenser"
           }
         ]
-      },
-      "diagnostics": "VNFKT - FIVE STAR HOMECARE LEEDS LTD - 02380798431"
+      }
+    }
+  ],
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "15075e01-f3eb-4788-b3ef-b7426fae633e",
+      "identifier": [
+        {
+          "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+          "value": "VNFKT"
+        }
+      ],
+      "name": "The Simple Pharmacy",
+      "telecom": [
+        {
+          "system": "phone",
+          "use": "work",
+          "value": "01133180277"
+        }
+      ],
+      "address": [
+        {
+          "use": "work",
+          "line": [
+            "17 Austhorpe Road",
+            "Crossgates",
+            "Leeds",
+            "West Yorkshire"
+          ],
+          "postalCode": "LS15 8BA"
+        }
+      ]
+    }
+  ],
+  "extension": [
+    {
+      "url": "https://fhir.nhs.uk/StructureDefinition/Extension-Spine-supportingInfo",
+      "valueReference": {
+        "reference": "#15075e01-f3eb-4788-b3ef-b7426fae633e"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

🎫 [AEA-5040](https://nhsd-jira.digital.nhs.uk/browse/AEA-5040) Release by id example is wrong for with another dispenser response

- Routine Change

### Details

This pull request corrects the error response example for cases where a prescription has already been released by another dispenser.