### PR TITLE
Docs: [AEA-4984] - OAS Update - Include description of the long-form id in the EPS FHIR API schema

### DIFF
--- a/packages/specification/schemas/components/_extensions/DMPrescriptionId.yaml
+++ b/packages/specification/schemas/components/_extensions/DMPrescriptionId.yaml
@@ -8,7 +8,9 @@ properties:
     enum: [https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId]
   valueIdentifier:
     type: object
-    description: The long-form identifier of the prescription.
+    description: |
+                The long form prescription id is a standard HL7 UUID, they must be represented in an upper case human-readable hexadecimal format where hyphen separators are used as per the example below and as defined by the 'datatype' schema within the message specification. UUID example: "C6ACA227-398E-47BC-8881-9A8BC763FC1C".
+                Both the long-form id and the short form id are unique to the prescription. The short form ID unique during the lifecycle of the prescription. The UUID for eternity (in theory). They are not related by maths or syntax but both are associated with the same prescription.
     required: [value, system]
     properties:
       system:


### PR DESCRIPTION
## Summary

🎫 [AEA-4984](https://nhsd-jira.digital.nhs.uk/browse/AEA-4984) OAS Update - Include description of the long-form id in the EPS FHIR API schema

- Routine Change

### Details

This pull request updates the EPS FHIR API schema to include a description of the long-form ID.